### PR TITLE
docker-composeの設定の修正

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,8 @@ services:
       - ./backend:/go/src/myapp
     command: "air"
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     environment:
       TZ: Asia/Tokyo
   frontend:
@@ -31,9 +32,15 @@ services:
     volumes:
       - ./docker/mysql:/var/lib/mysql
       - ./mysql/my.cnf:/etc/mysql/conf.d/my.cnf
-      - ./mysql/sql:/sqlscripts
+      - ./mysql/sql:/docker-entrypoint-initdb.d
     ports:
       - '3306:3306'
     environment:
       - MYSQL_ALLOW_EMPTY_PASSWORD=yes
       - MYSQL_DATABASE=training
+    healthcheck:
+      test: mysqladmin ping -h 127.0.0.1 -u root
+      interval: 5s
+      timeout: 30s
+      retries: 10
+      start_period: 5s


### PR DESCRIPTION
# 概要
- MySQLの立ち上げ時に、sqlファイルを実行するようにする
- MySQLに対してヘルスチェックを追加し、MySQLが立ち上がったのを確認してからバックエンドを起動する