### PR TITLE
APIドキュメント閲覧環境の作成

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Training app 2024
+
 ## docker-compose structure
 
 - backend:
@@ -30,8 +31,11 @@
 docker-compose up
 ```
 
-- backend: `http://localhost:9000`
-- frontend: `http://localhost:3000`
+- backend: http://localhost:9000
+- frontend: http://localhost:3000
+- api document(swagger ui): http://localhost:8000
+- api document(element): http://localhost:8010
+- api mockserver: http://localhost:8080
 
 でWebサーバが起動します。
 

--- a/api/api.yaml
+++ b/api/api.yaml
@@ -1,0 +1,21 @@
+openapi: "3.1.0"
+info:
+  title: "Training App API"
+  version: "1.0.0"
+servers:
+  - url: "http://localhost:8080"
+    description: "Mock Server"
+  - url: "http://localhost:9000"
+    description: "Development Server"
+paths:
+  /:
+    get:
+      operationId: "healthcheck"
+      responses:
+        200:
+          description: "Healthcheck"
+          content:
+            plain/text:
+              schema:
+                type: "string"
+                example: "It works"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,3 +56,24 @@ services:
       timeout: 30s
       retries: 10
       start_period: 5s
+  apidoc:
+    image: swaggerapi/swagger-ui
+    ports:
+      - '8000:8080'
+    volumes:
+      - ./api/api.yaml:/openapi.yaml
+    environment:
+      SWAGGER_JSON: /openapi.yaml
+  apidoc2:
+    build:
+      context: ./
+      dockerfile: ./docker/apidoc-element.Dockerfile
+    ports:
+      - '8010:80'
+  apimock:
+    image: stoplight/prism:5
+    ports:
+      - '8080:4010'
+    volumes:
+      - ./api/api.yaml:/openapi.yaml
+    command: 'mock -d -h 0.0.0.0 /openapi.yaml'

--- a/docker/apidoc-element.Dockerfile
+++ b/docker/apidoc-element.Dockerfile
@@ -1,0 +1,3 @@
+FROM nginx:1.27.0
+COPY ./docker/resource/api-doc.html /usr/share/nginx/html/index.html
+COPY ./api/api.yaml /usr/share/nginx/html/openapi.yaml

--- a/docker/resource/api-doc.html
+++ b/docker/resource/api-doc.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <title>Elements in HTML</title>
+    <!-- Embed elements Elements via Web Component -->
+    <script src="https://unpkg.com/@stoplight/elements/web-components.min.js"></script>
+    <link rel="stylesheet" href="https://unpkg.com/@stoplight/elements/styles.min.css">
+  </head>
+  <body>
+
+    <elements-api
+      apiDescriptionUrl="openapi.yaml"
+      router="hash"
+      layout="sidebar"
+    />
+
+  </body>
+</html>


### PR DESCRIPTION
# 概要
APIドキュメントと、その閲覧環境を追加する

# 変更内容
- `api/api.yaml`にAPIドキュメントを追加
- API Documentのビューアーとして`swagger-ui`及び`stoplight/element`をcomposeに追加
- mockとして`stoplight/prism`をcomposeに追加

# 動作確認
- http://localhost:8000 にアクセスして、Swagger UIを閲覧できる
- http://localhost:8010 にアクセスして、Elementを閲覧できる
- http://localhost:8080 にアクセスして、レスポンスが返ってくる