### PR TITLE
fix: biome target directory

### DIFF
--- a/.github/workflows/frontend.yaml
+++ b/.github/workflows/frontend.yaml
@@ -20,4 +20,4 @@ jobs:
           version: latest
           working-dir: frontend
       - name: Run Biome
-        run: biome ci .
+        run: biome ci ./frontend


### PR DESCRIPTION
# 概要
- biomeがgithub actions上で走査するディレクトリが変わってなかったので再度修正
- work_dirはあくまでlockファイルの走査対象だったみたい