### PR TITLE
取得したチャンネル一覧を JSON プロパティに変換する

### DIFF
--- a/backend/internal/controllers/get_channel_controller.go
+++ b/backend/internal/controllers/get_channel_controller.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"github.com/gin-gonic/gin"
 	"myapp/internal/repositories"
+	"time"
 )
 
 func GetChannels(ctx *gin.Context) {
@@ -18,3 +19,15 @@ func GetChannels(ctx *gin.Context) {
 	}
 }
 
+type ChannelsResponseJson struct {
+	Channels []ChannelJson `json:"channels"`
+}
+
+type ChannelJson struct {
+	Id        int       `json:"id"`
+	ServerId  int       `json:"serverId"`
+	Name      string    `json:"name"`
+	CreatedAt time.Time `json:"createdAt"`
+	UpdatedAt time.Time `json:"updatedAt"`
+	DeletedAt time.Time `json:"deletedAt"`
+}

--- a/backend/internal/controllers/get_channel_controller.go
+++ b/backend/internal/controllers/get_channel_controller.go
@@ -2,10 +2,11 @@ package controllers
 
 import (
 	"errors"
-	"github.com/gin-gonic/gin"
 	"myapp/internal/entities"
 	"myapp/internal/repositories"
 	"time"
+
+	"github.com/gin-gonic/gin"
 )
 
 func GetChannels(ctx *gin.Context) {
@@ -13,7 +14,7 @@ func GetChannels(ctx *gin.Context) {
 	channels, err := repository.Get()
 	if err != nil {
 		handleError(ctx, 500, err)
-	} else if channels != nil{
+	} else if channels != nil {
 		ctx.JSON(200, channelsConvertToJson(channels))
 	} else {
 		handleError(ctx, 404, errors.New("Not found"))

--- a/backend/internal/controllers/get_channel_controller.go
+++ b/backend/internal/controllers/get_channel_controller.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"errors"
 	"github.com/gin-gonic/gin"
+	"myapp/internal/entities"
 	"myapp/internal/repositories"
 	"time"
 )
@@ -13,10 +14,25 @@ func GetChannels(ctx *gin.Context) {
 	if err != nil {
 		handleError(ctx, 500, err)
 	} else if channels != nil{
-		ctx.JSON(200, channels)
+		ctx.JSON(200, channelsConvertToJson(channels))
 	} else {
 		handleError(ctx, 404, errors.New("Not found"))
 	}
+}
+
+func channelsConvertToJson(channels entities.Channels) ChannelsResponseJson {
+	jsonChannels := make([]ChannelJson, len(channels))
+	for i, v := range channels {
+		jsonChannels[i] = ChannelJson{
+			Id:        v.Id,
+			ServerId:  v.ServerId,
+			Name:      v.Name,
+			CreatedAt: v.CreatedAt,
+			UpdatedAt: v.UpdatedAt,
+			DeletedAt: v.DeletedAt,
+		}
+	}
+	return ChannelsResponseJson{Channels: jsonChannels}
 }
 
 type ChannelsResponseJson struct {

--- a/backend/internal/controllers/get_channel_controller.go
+++ b/backend/internal/controllers/get_channel_controller.go
@@ -30,7 +30,6 @@ func channelsConvertToJson(channels entities.Channels) ChannelsResponseJson {
 			Name:      v.Name,
 			CreatedAt: v.CreatedAt,
 			UpdatedAt: v.UpdatedAt,
-			DeletedAt: v.DeletedAt,
 		}
 	}
 	return ChannelsResponseJson{Channels: jsonChannels}
@@ -46,5 +45,4 @@ type ChannelJson struct {
 	Name      string    `json:"name"`
 	CreatedAt time.Time `json:"createdAt"`
 	UpdatedAt time.Time `json:"updatedAt"`
-	DeletedAt time.Time `json:"deletedAt"`
 }

--- a/backend/internal/middleware/router.go
+++ b/backend/internal/middleware/router.go
@@ -10,6 +10,6 @@ func SetupRoutes(app *gin.Engine) {
 	app.GET("/", func(ctx *gin.Context) {
 		ctx.String(200, "It works")
 	})
-	app.GET("/channel", controllers.GetChannels)
+	app.GET("/channels", controllers.GetChannels)
 	app.GET("/channels/:id/posts", controllers.GetPosts)
 }


### PR DESCRIPTION
## 概要
取得したチャンネル一覧の構造体に JSON のプロパティマップを適用した。

## Issues
Closes #33

## 動作確認
- `localhost:9000/channel` で以下のように取得できる。
```
{
  "channels":
    [
      {
        "id":1,
        "serverId":1,
        "name":"channel1",
        "createdAt":"2024-06-17T16:40:07+09:00",
        "updatedAt":"2024-06-17T16:40:07+09:00",
        "deletedAt":"0001-01-01T00:00:00Z"
      },
      {
        "id":2,
        "serverId":1,
        "name":"channel2",
        "createdAt":"2024-06-17T16:40:07+09:00",
        "updatedAt":"2024-06-17T16:40:07+09:00",
        "deletedAt":"0001-01-01T00:00:00Z"
      }
    ]
}
```