### PR TITLE
チャンネルを作成する API の実装

### DIFF
--- a/backend/internal/controllers/create_channel_controller.go
+++ b/backend/internal/controllers/create_channel_controller.go
@@ -9,8 +9,7 @@ import (
 )
 
 type createChannelsRequestParam struct {
-	ServerId int    `json:"server_id"`
-	Name     string `json:"name"`
+	Name string `json:"name"`
 }
 
 func CreateChannels(ctx *gin.Context) {

--- a/backend/internal/controllers/create_channel_controller.go
+++ b/backend/internal/controllers/create_channel_controller.go
@@ -31,7 +31,7 @@ func CreateChannels(ctx *gin.Context) {
 	}
 
 	usecase := usecases.NewCreateChannelUsecase()
-	if err := usecase.Execute(ctx, serverId); err != nil {
+	if err := usecase.Execute(ctx, serverId, param.Name); err != nil {
 		handleError(ctx, http.StatusBadRequest, err)
 	} else {
 		ctx.JSON(200, "")

--- a/backend/internal/controllers/create_channel_controller.go
+++ b/backend/internal/controllers/create_channel_controller.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"myapp/internal/repositories"
 	"myapp/internal/usecases"
 	"net/http"
 	"strconv"
@@ -29,8 +30,10 @@ func CreateChannels(ctx *gin.Context) {
 		handleError(ctx, http.StatusBadRequest, err)
 	}
 
-	usecase := usecases.NewCreateChannelUsecase()
-	result, err := usecase.Execute(ctx, serverId, param.Name)
+	serverRepository := repositories.NewGetServerRepository(DB(ctx))
+	createChannelRepository := repositories.NewCreateChannelRepository(DB(ctx))
+	usecase := usecases.NewCreateChannelUsecase(serverRepository, createChannelRepository)
+	result, err := usecase.Execute(serverId, param.Name)
 	if err != nil {
 		handleError(ctx, http.StatusBadRequest, err)
 	} else {

--- a/backend/internal/controllers/create_channel_controller.go
+++ b/backend/internal/controllers/create_channel_controller.go
@@ -1,10 +1,12 @@
 package controllers
 
 import (
+	"myapp/internal/entities"
 	"myapp/internal/repositories"
 	"myapp/internal/usecases"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/gin-gonic/gin"
 )
@@ -37,7 +39,23 @@ func CreateChannels(ctx *gin.Context) {
 	if err != nil {
 		handleError(ctx, http.StatusBadRequest, err)
 	} else {
-		ctx.JSON(200, result)
+		ctx.JSON(200, newChannelConvertToJson(result))
 	}
 
+}
+
+func newChannelConvertToJson(v *entities.Channel) newChannelJson {
+	return newChannelJson{
+		Id:        v.Id,
+		ServerId:  v.ServerId,
+		Name:      v.Name,
+		CreatedAt: v.CreatedAt,
+	}
+}
+
+type newChannelJson struct {
+	Id        int       `json:"id"`
+	ServerId  int       `json:"serverId"`
+	Name      string    `json:"name"`
+	CreatedAt time.Time `json:"createdAt"`
 }

--- a/backend/internal/controllers/create_channel_controller.go
+++ b/backend/internal/controllers/create_channel_controller.go
@@ -30,10 +30,11 @@ func CreateChannels(ctx *gin.Context) {
 	}
 
 	usecase := usecases.NewCreateChannelUsecase()
-	if err := usecase.Execute(ctx, serverId, param.Name); err != nil {
+	result, err := usecase.Execute(ctx, serverId, param.Name)
+	if err != nil {
 		handleError(ctx, http.StatusBadRequest, err)
 	} else {
-		ctx.JSON(200, "")
+		ctx.JSON(200, result)
 	}
 
 }

--- a/backend/internal/controllers/create_channel_controller.go
+++ b/backend/internal/controllers/create_channel_controller.go
@@ -1,0 +1,7 @@
+package controllers
+
+import "github.com/gin-gonic/gin"
+
+func CreateChannels(ctx *gin.Context) {
+
+}

--- a/backend/internal/controllers/create_channel_controller.go
+++ b/backend/internal/controllers/create_channel_controller.go
@@ -1,7 +1,40 @@
 package controllers
 
-import "github.com/gin-gonic/gin"
+import (
+	"myapp/internal/usecases"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+)
+
+type createChannelsRequestParam struct {
+	ServerId int    `json:"server_id"`
+	Name     string `json:"name"`
+}
 
 func CreateChannels(ctx *gin.Context) {
+	var param createChannelsRequestParam
+	serverId, err := strconv.Atoi(ctx.Param("id"))
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, err.Error())
+	}
+
+	if err := ctx.BindJSON(&param); err != nil {
+		handleError(ctx, http.StatusBadRequest, err)
+		return
+	}
+
+	// チャンネル名がない場合
+	if param.Name == "" {
+		handleError(ctx, http.StatusBadRequest, err)
+	}
+
+	usecase := usecases.NewCreateChannelUsecase()
+	if err := usecase.Execute(ctx, serverId); err != nil {
+		handleError(ctx, http.StatusBadRequest, err)
+	} else {
+		ctx.JSON(200, "")
+	}
 
 }

--- a/backend/internal/entities/server.go
+++ b/backend/internal/entities/server.go
@@ -1,0 +1,13 @@
+package entities
+
+import "time"
+
+type Server struct {
+	Id        int
+	OwnerId   int
+	Name      string
+	Icon      string
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	DeletedAt time.Time
+}

--- a/backend/internal/interfaces/create_channel_repository.go
+++ b/backend/internal/interfaces/create_channel_repository.go
@@ -1,0 +1,7 @@
+package interfaces
+
+import "myapp/internal/entities"
+
+type CreateChannelRepository interface {
+	Post(serverId int, name string) (*entities.Channel, error)
+}

--- a/backend/internal/interfaces/server_repository.go
+++ b/backend/internal/interfaces/server_repository.go
@@ -1,0 +1,7 @@
+package interfaces
+
+import "myapp/internal/entities"
+
+type ServerRepository interface {
+	Get(serverId int) (*entities.Server, error)
+}

--- a/backend/internal/middleware/router.go
+++ b/backend/internal/middleware/router.go
@@ -18,6 +18,7 @@ func SetupRoutes(app *gin.Engine) {
 	authorized.Use(Auth())
 	{
 		authorized.GET("/channels", controllers.GetChannels)
+		authorized.POST("/servers/:id/channels", controllers.CreateChannels)
 		authorized.GET("/channels/:id/posts", controllers.GetPosts)
 	}
 }

--- a/backend/internal/repositories/create_channel_repository.go
+++ b/backend/internal/repositories/create_channel_repository.go
@@ -1,0 +1,43 @@
+package repositories
+
+import (
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+type CreateChannelRepository struct {
+	Conn *gorm.DB
+}
+
+type createChannel struct {
+	Id        int
+	ServerId  int
+	Name      string
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	DeletedAt time.Time
+}
+
+func NewCreateChannelRepository(conn *gorm.DB) *CreateChannelRepository {
+	return &CreateChannelRepository{
+		Conn: conn,
+	}
+}
+
+func (r *CreateChannelRepository) Post(serverId int, name string) error {
+
+	channel := createChannel{}
+	r.Conn.Table("channels").Select("name").Where("name = ?", name).Find(&channel)
+	if channel.Name != "" {
+		// name がすでに使われている
+		return fmt.Errorf("%v", "その名前はすでに使用されています。")
+	}
+
+	// 新しいチャンネルのとき保存する
+	newChannel := createChannel{ServerId: serverId, Name: name}
+	r.Conn.Table("channels").Omit("DeletedAt").Create(&newChannel)
+
+	return nil
+}

--- a/backend/internal/repositories/server_repository.go
+++ b/backend/internal/repositories/server_repository.go
@@ -1,0 +1,31 @@
+package repositories
+
+import (
+	"errors"
+	"log"
+	"myapp/internal/entities"
+
+	"gorm.io/gorm"
+)
+
+type ServerRepository struct {
+	Conn *gorm.DB
+}
+
+func NewGetServerRepository(conn *gorm.DB) *ServerRepository {
+	return &ServerRepository{
+		Conn: conn,
+	}
+}
+
+func (r *ServerRepository) Get(serverId int) (*entities.Server, error) {
+	server := &entities.Server{}
+	if err := r.Conn.First(&server, serverId).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, entities.ErrNotFound
+		}
+		log.Printf("%v", err)
+		return nil, err
+	}
+	return server, nil
+}

--- a/backend/internal/usecases/create_channel_usecase.go
+++ b/backend/internal/usecases/create_channel_usecase.go
@@ -1,6 +1,7 @@
 package usecases
 
 import (
+	"myapp/internal/entities"
 	"myapp/internal/repositories"
 
 	"github.com/gin-gonic/gin"
@@ -13,7 +14,7 @@ func NewCreateChannelUsecase() *CreateChannelUsecase {
 	return &CreateChannelUsecase{}
 }
 
-func (uc *CreateChannelUsecase) Execute(ctx *gin.Context, serverId int, name string) error {
+func (uc *CreateChannelUsecase) Execute(ctx *gin.Context, serverId int, name string) (*entities.Channel, error) {
 	// 存在しているサーバーか確認する
 	serverRepository := repositories.NewGetServerRepository(DB(ctx))
 	if _, err := serverRepository.Get(serverId); err != nil {
@@ -21,6 +22,6 @@ func (uc *CreateChannelUsecase) Execute(ctx *gin.Context, serverId int, name str
 	}
 
 	repository := repositories.NewCreateChannelRepository(DB(ctx))
-	err := repository.Post(serverId, name)
-	return err
+	result, err := repository.Post(serverId, name)
+	return result, err
 }

--- a/backend/internal/usecases/create_channel_usecase.go
+++ b/backend/internal/usecases/create_channel_usecase.go
@@ -1,6 +1,10 @@
 package usecases
 
-import "github.com/gin-gonic/gin"
+import (
+	"myapp/internal/repositories"
+
+	"github.com/gin-gonic/gin"
+)
 
 type CreateChannelUsecase struct {
 }
@@ -9,6 +13,9 @@ func NewCreateChannelUsecase() *CreateChannelUsecase {
 	return &CreateChannelUsecase{}
 }
 
-func (uc *CreateChannelUsecase) Execute(ctx *gin.Context, serverId int) error {
-	return nil
+func (uc *CreateChannelUsecase) Execute(ctx *gin.Context, serverId int, name string) error {
+
+	repository := repositories.NewCreateChannelRepository(DB(ctx))
+	err := repository.Post(serverId, name)
+	return err
 }

--- a/backend/internal/usecases/create_channel_usecase.go
+++ b/backend/internal/usecases/create_channel_usecase.go
@@ -1,0 +1,14 @@
+package usecases
+
+import "github.com/gin-gonic/gin"
+
+type CreateChannelUsecase struct {
+}
+
+func NewCreateChannelUsecase() *CreateChannelUsecase {
+	return &CreateChannelUsecase{}
+}
+
+func (uc *CreateChannelUsecase) Execute(ctx *gin.Context, serverId int) error {
+	return nil
+}

--- a/backend/internal/usecases/create_channel_usecase.go
+++ b/backend/internal/usecases/create_channel_usecase.go
@@ -2,26 +2,27 @@ package usecases
 
 import (
 	"myapp/internal/entities"
-	"myapp/internal/repositories"
-
-	"github.com/gin-gonic/gin"
+	"myapp/internal/interfaces"
 )
 
 type CreateChannelUsecase struct {
+	serverRepository        interfaces.ServerRepository
+	createChannelRepository interfaces.CreateChannelRepository
 }
 
-func NewCreateChannelUsecase() *CreateChannelUsecase {
-	return &CreateChannelUsecase{}
+func NewCreateChannelUsecase(sr interfaces.ServerRepository, ccr interfaces.CreateChannelRepository) *CreateChannelUsecase {
+	return &CreateChannelUsecase{
+		serverRepository:        sr,
+		createChannelRepository: ccr,
+	}
 }
 
-func (uc *CreateChannelUsecase) Execute(ctx *gin.Context, serverId int, name string) (*entities.Channel, error) {
+func (uc *CreateChannelUsecase) Execute(serverId int, name string) (*entities.Channel, error) {
 	// 存在しているサーバーか確認する
-	serverRepository := repositories.NewGetServerRepository(DB(ctx))
-	if _, err := serverRepository.Get(serverId); err != nil {
+	if _, err := uc.serverRepository.Get(serverId); err != nil {
 		return nil, err
 	}
 
-	repository := repositories.NewCreateChannelRepository(DB(ctx))
-	result, err := repository.Post(serverId, name)
+	result, err := uc.createChannelRepository.Post(serverId, name)
 	return result, err
 }

--- a/backend/internal/usecases/create_channel_usecase.go
+++ b/backend/internal/usecases/create_channel_usecase.go
@@ -14,6 +14,11 @@ func NewCreateChannelUsecase() *CreateChannelUsecase {
 }
 
 func (uc *CreateChannelUsecase) Execute(ctx *gin.Context, serverId int, name string) error {
+	// 存在しているサーバーか確認する
+	serverRepository := repositories.NewGetServerRepository(DB(ctx))
+	if _, err := serverRepository.Get(serverId); err != nil {
+		return nil, err
+	}
 
 	repository := repositories.NewCreateChannelRepository(DB(ctx))
 	err := repository.Post(serverId, name)


### PR DESCRIPTION
## Issue
closes #45 

## 動作確認
### `サーバーID` と `チャンネル名` を渡して、正しく作成できると 200 が返ってくる
  ```
  % curl -H POST 'localhost:9000/servers/1/channels' -H 'Content-Type: application/json' -d '{"name" : "channel3"}' -H 'Authorization: Bearer {{ TOKEN }}'
  ```
> {"id":3, "serverId":1, "name":"channel3", "createdAt":"2024-06-25T18:34:41.459+09:00"}

- `servers` テーブルに存在するのは、`1` の `serverId` のサーバー
- `channels` テーブルに存在するのは、`channel1` / `channel2` という `name` のチャンネル
- 別途、JWT を取得しておいてください

#### すでに作成されているチャンネル名の場合、ダイヤログが返ってくる
- `channel1` は重複しているのでエラーを返す
  ```
  % curl -H POST 'localhost:9000/servers/1/channels' -H 'Content-Type: application/json' -d '{"name" : "channel1"}' -H 'Authorization: Bearer {{ TOKEN }}'
  ```
  
  > {"message":"その名前はすでに使用されています。"}%

#### 存在しないサーバー id の場合、ダイヤログが返ってくる
- `8` はテーブルに存在しないのでエラーを返す
  ```
  % curl -H POST 'localhost:9000/servers/8/channels' -H 'Content-Type: application/json' -d '{"name" : "channel1"}' -H 'Authorization: Bearer {{ TOKEN }}'
  ```
  
  > {"message":"Item is not found"}%