### PR TITLE
Backend側にcors用の設定を追加

### DIFF
--- a/backend/internal/middleware/cors.go
+++ b/backend/internal/middleware/cors.go
@@ -10,5 +10,16 @@ func Cors() gin.HandlerFunc {
 	config := cors.DefaultConfig()
 	config.AllowOrigins = []string{myConfig.CorsAllowOrigin}
 	config.AllowCredentials = true
+	config.AllowMethods = []string{
+		"POST",
+		"GET",
+		"OPTIONS",
+	}
+	config.AllowHeaders = []string{
+		"Access-Control-Allow-Credentials",
+		"Access-Control-Allow-Headers",
+		"Content-Type",
+		"Authorization",
+	}
 	return cors.New(config)
 }


### PR DESCRIPTION
# 概要
- api通信の際に必要な設定が足りなかった（Auth Headerを追加したことにより足りなくなった）ので追加
- Credentials: include にしたらまたこの辺変更するかも…