### PR TITLE
Frontend/#54 Inputコンポーネントの実装

### DIFF
--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -5,3 +5,4 @@ export { Icon } from "./icon";
 export { IconButton } from "./icon-button";
 export { IconImage } from "./icon-image";
 export { Text } from "./text";
+export { Input } from "./input";

--- a/frontend/src/components/ui/input/index.ts
+++ b/frontend/src/components/ui/input/index.ts
@@ -1,0 +1,1 @@
+export { Input } from "./input";

--- a/frontend/src/components/ui/input/input.module.scss
+++ b/frontend/src/components/ui/input/input.module.scss
@@ -1,0 +1,16 @@
+.input {
+  padding: 0.5rem 1.25rem;
+  border-radius: var(--radius-lg);
+  width: 100%;
+  outline: 1px solid var(--c-gray-50);
+  border: none;
+  transition: outline 0.2s;
+
+  &::placeholder {
+    color: var(--c-gray-200);
+  }
+
+  &:focus {
+    outline: 1px solid var(--c-primary);
+  }
+}

--- a/frontend/src/components/ui/input/input.stories.tsx
+++ b/frontend/src/components/ui/input/input.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryFn } from "@storybook/react";
+
+import type { ComponentProps } from "react";
+import { Input } from "./input";
+
+export default {
+	title: "Components/Input",
+	component: Input,
+	tags: ["autodocs"],
+} as Meta;
+
+const Template: StoryFn<ComponentProps<typeof Input>> = (args) => (
+	<Input {...args} />
+);
+
+export const Default = Template.bind({});
+Default.args = {
+	placeholder: "Enter your name",
+};

--- a/frontend/src/components/ui/input/input.tsx
+++ b/frontend/src/components/ui/input/input.tsx
@@ -3,6 +3,9 @@ import styles from "./input.module.scss";
 type Props = React.InputHTMLAttributes<HTMLInputElement>;
 
 export const Input = ({ name, value, onChange, ...rest }: Props) => {
+	const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+		onChange?.(e);
+	};
 	return (
 		<input
 			type="text"
@@ -10,7 +13,7 @@ export const Input = ({ name, value, onChange, ...rest }: Props) => {
 			name={name}
 			id={name}
 			value={value}
-			onChange={onChange}
+			onChange={handleChange}
 			{...rest}
 		/>
 	);

--- a/frontend/src/components/ui/input/input.tsx
+++ b/frontend/src/components/ui/input/input.tsx
@@ -1,14 +1,17 @@
 import styles from "./input.module.scss";
 
-type Props = React.InputHTMLAttributes<HTMLInputElement>;
+type Props = React.InputHTMLAttributes<HTMLInputElement> & {
+	type: "text" | "password" | "email";
+};
 
-export const Input = ({ name, value, onChange, ...rest }: Props) => {
+export const Input = ({ type, name, value, onChange, ...rest }: Props) => {
 	const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 		onChange?.(e);
 	};
+
 	return (
 		<input
-			type="text"
+			type={type}
 			className={styles.input}
 			name={name}
 			id={name}

--- a/frontend/src/components/ui/input/input.tsx
+++ b/frontend/src/components/ui/input/input.tsx
@@ -1,0 +1,17 @@
+import styles from "./input.module.scss";
+
+type Props = React.InputHTMLAttributes<HTMLInputElement>;
+
+export const Input = ({ name, value, onChange, ...rest }: Props) => {
+	return (
+		<input
+			type="text"
+			className={styles.input}
+			name={name}
+			id={name}
+			value={value}
+			onChange={onChange}
+			{...rest}
+		/>
+	);
+};


### PR DESCRIPTION
# 概要
- Inputコンポーネントを実装
  - type=textのみ

# 動作確認
- [x] http://localhost:6001/?path=/docs/components-input--docs にアクセスする
- [x] Inputコンポーネントが表示される
- [x] Inputコンポーネントに文字を入力することができる
- [x] Placeholderの文字列を変えると、コンポーネントにも反映される

close #54 