### PR TITLE
Frontend/#55 textareaコンポーネントの実装

### DIFF
--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -5,3 +5,4 @@ export { Icon } from "./icon";
 export { IconButton } from "./icon-button";
 export { IconImage } from "./icon-image";
 export { Text } from "./text";
+export { Textarea } from "./textarea";

--- a/frontend/src/components/ui/textarea/index.ts
+++ b/frontend/src/components/ui/textarea/index.ts
@@ -1,0 +1,1 @@
+export { Textarea } from "./textarea";

--- a/frontend/src/components/ui/textarea/textarea.module.scss
+++ b/frontend/src/components/ui/textarea/textarea.module.scss
@@ -1,0 +1,18 @@
+.textarea {
+  width: 100%;
+  padding: 1rem;
+  border-radius: var(--radius-sm);
+  border: none;
+  outline: 1px solid;
+  outline-color: var(--c-gray-100);
+  resize: none;
+  transition: outline-color 0.2s;
+
+  &::placeholder {
+    color: var(--c-gray-200);
+  }
+
+  &:focus {
+    outline-color: var(--c-primary);
+  }
+}

--- a/frontend/src/components/ui/textarea/textarea.stories.tsx
+++ b/frontend/src/components/ui/textarea/textarea.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryFn } from "@storybook/react";
+
+import type { ComponentProps } from "react";
+import { Textarea } from "./textarea";
+
+export default {
+	title: "Components/Textarea",
+	component: Textarea,
+	tags: ["autodocs"],
+} as Meta;
+
+const Template: StoryFn<ComponentProps<typeof Textarea>> = (args) => (
+	<Textarea {...args} />
+);
+
+export const Default = Template.bind({});
+Default.args = {
+	rows: 3,
+	placeholder: "Type here...",
+};

--- a/frontend/src/components/ui/textarea/textarea.tsx
+++ b/frontend/src/components/ui/textarea/textarea.tsx
@@ -1,0 +1,31 @@
+import styles from "./textarea.module.scss";
+
+type Props = {
+	rows?: number;
+	defaultValue?: string;
+	value?: string;
+	placeholder?: string;
+	onChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+};
+
+export const Textarea = ({
+	rows = 3,
+	defaultValue,
+	value,
+	placeholder,
+	onChange,
+}: Props) => {
+	const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+		onChange?.(e);
+	};
+	return (
+		<textarea
+			className={styles.textarea}
+			rows={rows}
+			defaultValue={defaultValue}
+			value={value}
+			onChange={handleChange}
+			placeholder={placeholder}
+		/>
+	);
+};


### PR DESCRIPTION
# 概要
- Textareaコンポーネントを実装
  - 投稿作成用

# 動作確認
- http://localhost:6001/?path=/docs/components-textarea--docs にアクセスする
- Textareaコンポーネントが表示される
- Textareaに文字が入力できる
- Placeholderの文字を変えると、コンポーネントにも反映される

close #55 