### PR TITLE
Frontend/#11 サーバー一覧表示コンポーネントを作成

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,6 +22,7 @@
 				"@storybook/addon-links": "^8.1.4",
 				"@storybook/cli": "^8.1.4",
 				"@storybook/react-vite": "^8.1.4",
+				"@storybook/test": "^8.1.10",
 				"@tanstack/router-devtools": "^1.38.1",
 				"@tanstack/router-vite-plugin": "^1.38.0",
 				"@types/node": "^20.12.12",
@@ -42,6 +43,12 @@
 				"vite": "^5.2.0",
 				"vitest": "^1.6.0"
 			}
+		},
+		"node_modules/@adobe/css-tools": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.0.tgz",
+			"integrity": "sha512-Ff9+ksdQQB3rMncgqDK78uLznstjyfIf2Arnh22pW8kBpLs6rpKDwgnZT46hin5Hl1WzazzK64DOrhSwYpS7bQ==",
+			"dev": true
 		},
 		"node_modules/@ampproject/remapping": {
 			"version": "2.3.0",
@@ -3606,24 +3613,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/@storybook/addon-actions": {
-			"version": "8.1.4",
-			"resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-8.1.4.tgz",
-			"integrity": "sha512-3q/DCcnSjpuWBoKpA+0j1etXyMOu+GsdUtxv041tsNjMMwyc+CfHUGiAHMyQ0TpEf8MPQoTeZsRPrEZwVUNXow==",
-			"dev": true,
-			"dependencies": {
-				"@storybook/core-events": "8.1.4",
-				"@storybook/global": "^5.0.0",
-				"@types/uuid": "^9.0.1",
-				"dequal": "^2.0.2",
-				"polished": "^4.2.2",
-				"uuid": "^9.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/storybook"
-			}
-		},
 		"node_modules/@storybook/addon-backgrounds": {
 			"version": "8.1.4",
 			"resolved": "https://registry.npmjs.org/@storybook/addon-backgrounds/-/addon-backgrounds-8.1.4.tgz",
@@ -3707,6 +3696,24 @@
 				"@storybook/node-logger": "8.1.4",
 				"@storybook/preview-api": "8.1.4",
 				"ts-dedent": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/storybook"
+			}
+		},
+		"node_modules/@storybook/addon-essentials/node_modules/@storybook/addon-actions": {
+			"version": "8.1.4",
+			"resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-8.1.4.tgz",
+			"integrity": "sha512-3q/DCcnSjpuWBoKpA+0j1etXyMOu+GsdUtxv041tsNjMMwyc+CfHUGiAHMyQ0TpEf8MPQoTeZsRPrEZwVUNXow==",
+			"dev": true,
+			"dependencies": {
+				"@storybook/core-events": "8.1.4",
+				"@storybook/global": "^5.0.0",
+				"@types/uuid": "^9.0.1",
+				"dequal": "^2.0.2",
+				"polished": "^4.2.2",
+				"uuid": "^9.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -6128,6 +6135,110 @@
 				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
 			}
 		},
+		"node_modules/@storybook/instrumenter": {
+			"version": "8.1.10",
+			"resolved": "https://registry.npmjs.org/@storybook/instrumenter/-/instrumenter-8.1.10.tgz",
+			"integrity": "sha512-/TZ3JpTCorbhThCfaR5k4Vs0Svp6xz6t+FVaim/v7N9VErEfmtn+d76CqYLfvmo68DzkEzvArOFBdh2MXtscsw==",
+			"dev": true,
+			"dependencies": {
+				"@storybook/channels": "8.1.10",
+				"@storybook/client-logger": "8.1.10",
+				"@storybook/core-events": "8.1.10",
+				"@storybook/global": "^5.0.0",
+				"@storybook/preview-api": "8.1.10",
+				"@vitest/utils": "^1.3.1",
+				"util": "^0.12.4"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/storybook"
+			}
+		},
+		"node_modules/@storybook/instrumenter/node_modules/@storybook/channels": {
+			"version": "8.1.10",
+			"resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-8.1.10.tgz",
+			"integrity": "sha512-CxZE4XrQoe+F+S2mo8Z9HTvFZKfKHIIiwYfoXKCryVp2U/z7ZKrely2PbfxWsrQvF3H0+oegfYYhYRHRiM21Zw==",
+			"dev": true,
+			"dependencies": {
+				"@storybook/client-logger": "8.1.10",
+				"@storybook/core-events": "8.1.10",
+				"@storybook/global": "^5.0.0",
+				"telejson": "^7.2.0",
+				"tiny-invariant": "^1.3.1"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/storybook"
+			}
+		},
+		"node_modules/@storybook/instrumenter/node_modules/@storybook/client-logger": {
+			"version": "8.1.10",
+			"resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-8.1.10.tgz",
+			"integrity": "sha512-sVXCOo7jnlCgRPOcMlQGODAEt6ipPj+8xGkRUws0kie77qiDld1drLSB6R380dWc9lUrbv9E1GpxCd/Y4ZzSJQ==",
+			"dev": true,
+			"dependencies": {
+				"@storybook/global": "^5.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/storybook"
+			}
+		},
+		"node_modules/@storybook/instrumenter/node_modules/@storybook/core-events": {
+			"version": "8.1.10",
+			"resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-8.1.10.tgz",
+			"integrity": "sha512-aS4zsBVyJds74+rAW0IfTEjULDCQwXecVpQfv11B8/89/07s3bOPssGGoTtCTaN4pHbduywE6MxbmFvTmXOFCA==",
+			"dev": true,
+			"dependencies": {
+				"@storybook/csf": "^0.1.7",
+				"ts-dedent": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/storybook"
+			}
+		},
+		"node_modules/@storybook/instrumenter/node_modules/@storybook/preview-api": {
+			"version": "8.1.10",
+			"resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-8.1.10.tgz",
+			"integrity": "sha512-0Gl8WHDtp/srrA5uBYXl7YbC8kFQA7IxVmwWN7dIS7HAXu63JZ6JfxaFcfy+kCBfZSBD7spFG4J0f5JXRDYbpg==",
+			"dev": true,
+			"dependencies": {
+				"@storybook/channels": "8.1.10",
+				"@storybook/client-logger": "8.1.10",
+				"@storybook/core-events": "8.1.10",
+				"@storybook/csf": "^0.1.7",
+				"@storybook/global": "^5.0.0",
+				"@storybook/types": "8.1.10",
+				"@types/qs": "^6.9.5",
+				"dequal": "^2.0.2",
+				"lodash": "^4.17.21",
+				"memoizerific": "^1.11.3",
+				"qs": "^6.10.0",
+				"tiny-invariant": "^1.3.1",
+				"ts-dedent": "^2.0.0",
+				"util-deprecate": "^1.0.2"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/storybook"
+			}
+		},
+		"node_modules/@storybook/instrumenter/node_modules/@storybook/types": {
+			"version": "8.1.10",
+			"resolved": "https://registry.npmjs.org/@storybook/types/-/types-8.1.10.tgz",
+			"integrity": "sha512-UJ97iqI+0Mk13I6ayd3TaBfSFBkWnEauwTnFMQe1dN/L3wTh8laOBaLa0Vr3utRSnt2b5hpcw/nq7azB/Gx4Yw==",
+			"dev": true,
+			"dependencies": {
+				"@storybook/channels": "8.1.10",
+				"@types/express": "^4.7.0",
+				"file-system-cache": "2.3.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/storybook"
+			}
+		},
 		"node_modules/@storybook/manager": {
 			"version": "8.1.10",
 			"resolved": "https://registry.npmjs.org/@storybook/manager/-/manager-8.1.10.tgz",
@@ -6814,6 +6925,154 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/@storybook/test": {
+			"version": "8.1.10",
+			"resolved": "https://registry.npmjs.org/@storybook/test/-/test-8.1.10.tgz",
+			"integrity": "sha512-uskw/xb/GkGLRTEKPao/5xUKxjP1X3DnDpE52xDF46ZmTvM+gPQbkex97qdG6Mfv37/0lhVhufAsV3g5+CrYKQ==",
+			"dev": true,
+			"dependencies": {
+				"@storybook/client-logger": "8.1.10",
+				"@storybook/core-events": "8.1.10",
+				"@storybook/instrumenter": "8.1.10",
+				"@storybook/preview-api": "8.1.10",
+				"@testing-library/dom": "^9.3.4",
+				"@testing-library/jest-dom": "^6.4.2",
+				"@testing-library/user-event": "^14.5.2",
+				"@vitest/expect": "1.3.1",
+				"@vitest/spy": "^1.3.1",
+				"util": "^0.12.4"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/storybook"
+			}
+		},
+		"node_modules/@storybook/test/node_modules/@storybook/channels": {
+			"version": "8.1.10",
+			"resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-8.1.10.tgz",
+			"integrity": "sha512-CxZE4XrQoe+F+S2mo8Z9HTvFZKfKHIIiwYfoXKCryVp2U/z7ZKrely2PbfxWsrQvF3H0+oegfYYhYRHRiM21Zw==",
+			"dev": true,
+			"dependencies": {
+				"@storybook/client-logger": "8.1.10",
+				"@storybook/core-events": "8.1.10",
+				"@storybook/global": "^5.0.0",
+				"telejson": "^7.2.0",
+				"tiny-invariant": "^1.3.1"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/storybook"
+			}
+		},
+		"node_modules/@storybook/test/node_modules/@storybook/client-logger": {
+			"version": "8.1.10",
+			"resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-8.1.10.tgz",
+			"integrity": "sha512-sVXCOo7jnlCgRPOcMlQGODAEt6ipPj+8xGkRUws0kie77qiDld1drLSB6R380dWc9lUrbv9E1GpxCd/Y4ZzSJQ==",
+			"dev": true,
+			"dependencies": {
+				"@storybook/global": "^5.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/storybook"
+			}
+		},
+		"node_modules/@storybook/test/node_modules/@storybook/core-events": {
+			"version": "8.1.10",
+			"resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-8.1.10.tgz",
+			"integrity": "sha512-aS4zsBVyJds74+rAW0IfTEjULDCQwXecVpQfv11B8/89/07s3bOPssGGoTtCTaN4pHbduywE6MxbmFvTmXOFCA==",
+			"dev": true,
+			"dependencies": {
+				"@storybook/csf": "^0.1.7",
+				"ts-dedent": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/storybook"
+			}
+		},
+		"node_modules/@storybook/test/node_modules/@storybook/preview-api": {
+			"version": "8.1.10",
+			"resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-8.1.10.tgz",
+			"integrity": "sha512-0Gl8WHDtp/srrA5uBYXl7YbC8kFQA7IxVmwWN7dIS7HAXu63JZ6JfxaFcfy+kCBfZSBD7spFG4J0f5JXRDYbpg==",
+			"dev": true,
+			"dependencies": {
+				"@storybook/channels": "8.1.10",
+				"@storybook/client-logger": "8.1.10",
+				"@storybook/core-events": "8.1.10",
+				"@storybook/csf": "^0.1.7",
+				"@storybook/global": "^5.0.0",
+				"@storybook/types": "8.1.10",
+				"@types/qs": "^6.9.5",
+				"dequal": "^2.0.2",
+				"lodash": "^4.17.21",
+				"memoizerific": "^1.11.3",
+				"qs": "^6.10.0",
+				"tiny-invariant": "^1.3.1",
+				"ts-dedent": "^2.0.0",
+				"util-deprecate": "^1.0.2"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/storybook"
+			}
+		},
+		"node_modules/@storybook/test/node_modules/@storybook/types": {
+			"version": "8.1.10",
+			"resolved": "https://registry.npmjs.org/@storybook/types/-/types-8.1.10.tgz",
+			"integrity": "sha512-UJ97iqI+0Mk13I6ayd3TaBfSFBkWnEauwTnFMQe1dN/L3wTh8laOBaLa0Vr3utRSnt2b5hpcw/nq7azB/Gx4Yw==",
+			"dev": true,
+			"dependencies": {
+				"@storybook/channels": "8.1.10",
+				"@types/express": "^4.7.0",
+				"file-system-cache": "2.3.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/storybook"
+			}
+		},
+		"node_modules/@storybook/test/node_modules/@vitest/expect": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.3.1.tgz",
+			"integrity": "sha512-xofQFwIzfdmLLlHa6ag0dPV8YsnKOCP1KdAeVVh34vSjN2dcUiXYCD9htu/9eM7t8Xln4v03U9HLxLpPlsXdZw==",
+			"dev": true,
+			"dependencies": {
+				"@vitest/spy": "1.3.1",
+				"@vitest/utils": "1.3.1",
+				"chai": "^4.3.10"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@storybook/test/node_modules/@vitest/spy": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.3.1.tgz",
+			"integrity": "sha512-xAcW+S099ylC9VLU7eZfdT9myV67Nor9w9zhf0mGCYJSO+zM2839tOeROTdikOi/8Qeusffvxb/MyBSOja1Uig==",
+			"dev": true,
+			"dependencies": {
+				"tinyspy": "^2.2.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@storybook/test/node_modules/@vitest/utils": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.3.1.tgz",
+			"integrity": "sha512-d3Waie/299qqRyHTm2DjADeTaNdNSVsnwHPWrs20JMpjh6eiVq7ggggweO8rc4arhf6rRkWuHKwvxGvejUXZZQ==",
+			"dev": true,
+			"dependencies": {
+				"diff-sequences": "^29.6.3",
+				"estree-walker": "^3.0.3",
+				"loupe": "^2.3.7",
+				"pretty-format": "^29.7.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
 		"node_modules/@storybook/theming": {
 			"version": "8.1.4",
 			"resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-8.1.4.tgz",
@@ -7011,6 +7270,264 @@
 				"type": "github",
 				"url": "https://github.com/sponsors/tannerlinsley"
 			}
+		},
+		"node_modules/@testing-library/dom": {
+			"version": "9.3.4",
+			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.4.tgz",
+			"integrity": "sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/code-frame": "^7.10.4",
+				"@babel/runtime": "^7.12.5",
+				"@types/aria-query": "^5.0.1",
+				"aria-query": "5.1.3",
+				"chalk": "^4.1.0",
+				"dom-accessibility-api": "^0.5.9",
+				"lz-string": "^1.5.0",
+				"pretty-format": "^27.0.2"
+			},
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@testing-library/dom/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@testing-library/dom/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/@testing-library/dom/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/@testing-library/dom/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true
+		},
+		"node_modules/@testing-library/dom/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@testing-library/dom/node_modules/pretty-format": {
+			"version": "27.5.1",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1",
+				"ansi-styles": "^5.0.0",
+				"react-is": "^17.0.1"
+			},
+			"engines": {
+				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+			}
+		},
+		"node_modules/@testing-library/dom/node_modules/pretty-format/node_modules/ansi-styles": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@testing-library/dom/node_modules/react-is": {
+			"version": "17.0.2",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+			"dev": true
+		},
+		"node_modules/@testing-library/dom/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@testing-library/jest-dom": {
+			"version": "6.4.6",
+			"resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.4.6.tgz",
+			"integrity": "sha512-8qpnGVincVDLEcQXWaHOf6zmlbwTKc6Us6PPu4CRnPXCzo2OGBS5cwgMMOWdxDpEz1mkbvXHpEy99M5Yvt682w==",
+			"dev": true,
+			"dependencies": {
+				"@adobe/css-tools": "^4.4.0",
+				"@babel/runtime": "^7.9.2",
+				"aria-query": "^5.0.0",
+				"chalk": "^3.0.0",
+				"css.escape": "^1.5.1",
+				"dom-accessibility-api": "^0.6.3",
+				"lodash": "^4.17.21",
+				"redent": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=14",
+				"npm": ">=6",
+				"yarn": ">=1"
+			},
+			"peerDependencies": {
+				"@jest/globals": ">= 28",
+				"@types/bun": "latest",
+				"@types/jest": ">= 28",
+				"jest": ">= 28",
+				"vitest": ">= 0.32"
+			},
+			"peerDependenciesMeta": {
+				"@jest/globals": {
+					"optional": true
+				},
+				"@types/bun": {
+					"optional": true
+				},
+				"@types/jest": {
+					"optional": true
+				},
+				"jest": {
+					"optional": true
+				},
+				"vitest": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@testing-library/jest-dom/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@testing-library/jest-dom/node_modules/chalk": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+			"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@testing-library/jest-dom/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/@testing-library/jest-dom/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true
+		},
+		"node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+			"integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+			"dev": true
+		},
+		"node_modules/@testing-library/jest-dom/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@testing-library/jest-dom/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@testing-library/user-event": {
+			"version": "14.5.2",
+			"resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.2.tgz",
+			"integrity": "sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=12",
+				"npm": ">=6"
+			},
+			"peerDependencies": {
+				"@testing-library/dom": ">=7.21.4"
+			}
+		},
+		"node_modules/@types/aria-query": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+			"integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+			"dev": true
 		},
 		"node_modules/@types/babel__core": {
 			"version": "7.20.5",
@@ -7808,6 +8325,31 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
 			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
 			"dev": true
+		},
+		"node_modules/aria-query": {
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
+			"integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
+			"dev": true,
+			"dependencies": {
+				"deep-equal": "^2.0.5"
+			}
+		},
+		"node_modules/array-buffer-byte-length": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
+			"integrity": "sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.5",
+				"is-array-buffer": "^3.0.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/array-flatten": {
 			"version": "1.1.1",
@@ -8646,6 +9188,12 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/css.escape": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+			"integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+			"dev": true
+		},
 		"node_modules/csstype": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -8696,6 +9244,44 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/deep-equal": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
+			"integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
+			"dev": true,
+			"dependencies": {
+				"array-buffer-byte-length": "^1.0.0",
+				"call-bind": "^1.0.5",
+				"es-get-iterator": "^1.1.3",
+				"get-intrinsic": "^1.2.2",
+				"is-arguments": "^1.1.1",
+				"is-array-buffer": "^3.0.2",
+				"is-date-object": "^1.0.5",
+				"is-regex": "^1.1.4",
+				"is-shared-array-buffer": "^1.0.2",
+				"isarray": "^2.0.5",
+				"object-is": "^1.1.5",
+				"object-keys": "^1.1.1",
+				"object.assign": "^4.1.4",
+				"regexp.prototype.flags": "^1.5.1",
+				"side-channel": "^1.0.4",
+				"which-boxed-primitive": "^1.0.2",
+				"which-collection": "^1.0.1",
+				"which-typed-array": "^1.1.13"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/deep-equal/node_modules/isarray": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+			"dev": true
 		},
 		"node_modules/deep-is": {
 			"version": "0.1.4",
@@ -9023,6 +9609,12 @@
 				"node": ">=6.0.0"
 			}
 		},
+		"node_modules/dom-accessibility-api": {
+			"version": "0.5.16",
+			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+			"integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+			"dev": true
+		},
 		"node_modules/dotenv": {
 			"version": "16.4.5",
 			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
@@ -9184,6 +9776,32 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
+		},
+		"node_modules/es-get-iterator": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+			"integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"get-intrinsic": "^1.1.3",
+				"has-symbols": "^1.0.3",
+				"is-arguments": "^1.1.1",
+				"is-map": "^2.0.2",
+				"is-set": "^2.0.2",
+				"is-string": "^1.0.7",
+				"isarray": "^2.0.5",
+				"stop-iteration-iterator": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/es-get-iterator/node_modules/isarray": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+			"dev": true
 		},
 		"node_modules/es-module-lexer": {
 			"version": "1.5.3",
@@ -10111,6 +10729,15 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/functions-have-names": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+			"integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/gensync": {
 			"version": "1.0.0-beta.2",
 			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -10383,6 +11010,15 @@
 				"uglify-js": "^3.1.4"
 			}
 		},
+		"node_modules/has-bigints": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+			"integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -10635,6 +11271,20 @@
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 			"dev": true
 		},
+		"node_modules/internal-slot": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
+			"integrity": "sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==",
+			"dev": true,
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"hasown": "^2.0.0",
+				"side-channel": "^1.0.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/invariant": {
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
@@ -10681,11 +11331,39 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/is-array-buffer": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
+			"integrity": "sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"get-intrinsic": "^1.2.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
 			"integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
 			"dev": true
+		},
+		"node_modules/is-bigint": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+			"integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+			"dev": true,
+			"dependencies": {
+				"has-bigints": "^1.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/is-binary-path": {
 			"version": "2.1.0",
@@ -10697,6 +11375,22 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/is-boolean-object": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+			"integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-callable": {
@@ -10718,6 +11412,21 @@
 			"dev": true,
 			"dependencies": {
 				"hasown": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-date-object": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+			"integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+			"dev": true,
+			"dependencies": {
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -10807,6 +11516,18 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/is-map": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+			"integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/is-nan": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
@@ -10830,6 +11551,21 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.12.0"
+			}
+		},
+		"node_modules/is-number-object": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+			"integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
+			"dev": true,
+			"dependencies": {
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-path-cwd": {
@@ -10859,6 +11595,49 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/is-regex": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+			"integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-set": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+			"integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-shared-array-buffer": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.3.tgz",
+			"integrity": "sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.7"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/is-stream": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
@@ -10869,6 +11648,36 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-string": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+			"integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+			"dev": true,
+			"dependencies": {
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-symbol": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+			"integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+			"dev": true,
+			"dependencies": {
+				"has-symbols": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-typed-array": {
@@ -10896,6 +11705,34 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-weakmap": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+			"integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-weakset": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.3.tgz",
+			"integrity": "sha512-LvIm3/KWzS9oRFHugab7d+M/GcBXuXX5xZkzPmN+NxihdQlZUQ4dWuSV1xR/sq6upL1TJEDrfBgRepHFdBtSNQ==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"get-intrinsic": "^1.2.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-wsl": {
@@ -11487,6 +12324,15 @@
 			"dev": true,
 			"dependencies": {
 				"yallist": "^3.0.2"
+			}
+		},
+		"node_modules/lz-string": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+			"integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+			"dev": true,
+			"bin": {
+				"lz-string": "bin/bin.js"
 			}
 		},
 		"node_modules/magic-string": {
@@ -15715,6 +16561,31 @@
 			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
 			"dev": true
 		},
+		"node_modules/redent": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+			"integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+			"dev": true,
+			"dependencies": {
+				"indent-string": "^4.0.0",
+				"strip-indent": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/redent/node_modules/strip-indent": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+			"integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+			"dev": true,
+			"dependencies": {
+				"min-indent": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/regenerate": {
 			"version": "1.4.2",
 			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -15746,6 +16617,24 @@
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.8.4"
+			}
+		},
+		"node_modules/regexp.prototype.flags": {
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
+			"integrity": "sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.6",
+				"define-properties": "^1.2.1",
+				"es-errors": "^1.3.0",
+				"set-function-name": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/regexpu-core": {
@@ -16114,6 +17003,21 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/set-function-name": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+			"integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+			"dev": true,
+			"dependencies": {
+				"define-data-property": "^1.1.4",
+				"es-errors": "^1.3.0",
+				"functions-have-names": "^1.2.3",
+				"has-property-descriptors": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/setprototypeof": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -16294,6 +17198,18 @@
 			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.7.0.tgz",
 			"integrity": "sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==",
 			"dev": true
+		},
+		"node_modules/stop-iteration-iterator": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz",
+			"integrity": "sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==",
+			"dev": true,
+			"dependencies": {
+				"internal-slot": "^1.0.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
 		},
 		"node_modules/store2": {
 			"version": "2.14.3",
@@ -17430,6 +18346,40 @@
 			},
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/which-boxed-primitive": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+			"integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+			"dev": true,
+			"dependencies": {
+				"is-bigint": "^1.0.1",
+				"is-boolean-object": "^1.1.0",
+				"is-number-object": "^1.0.4",
+				"is-string": "^1.0.5",
+				"is-symbol": "^1.0.3"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/which-collection": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+			"integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+			"dev": true,
+			"dependencies": {
+				"is-map": "^2.0.3",
+				"is-set": "^2.0.3",
+				"is-weakmap": "^2.0.2",
+				"is-weakset": "^2.0.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/which-typed-array": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
 		"@storybook/addon-links": "^8.1.4",
 		"@storybook/cli": "^8.1.4",
 		"@storybook/react-vite": "^8.1.4",
+		"@storybook/test": "^8.1.10",
 		"@tanstack/router-devtools": "^1.38.1",
 		"@tanstack/router-vite-plugin": "^1.38.0",
 		"@types/node": "^20.12.12",

--- a/frontend/src/components/model/server/index.ts
+++ b/frontend/src/components/model/server/index.ts
@@ -1,0 +1,1 @@
+export { ServerList } from "./server-list";

--- a/frontend/src/components/model/server/server-list.module.scss
+++ b/frontend/src/components/model/server/server-list.module.scss
@@ -1,0 +1,23 @@
+.root {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+}
+
+.link {
+  text-decoration: none;
+  color: var(--c-text-main);
+}
+
+.item {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  border-radius: var(--radius-sm);
+
+  &:hover {
+    background-color: var(--c-gray-50);
+  }
+}

--- a/frontend/src/components/model/server/server-list.stories.tsx
+++ b/frontend/src/components/model/server/server-list.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryFn } from "@storybook/react";
+
+import { fn } from "@storybook/test";
+import type { ComponentProps } from "react";
+import { ServerList } from "./server-list";
+
+export default {
+	title: "Components/Model/Server/ServerList",
+	component: ServerList,
+	tags: ["autodocs"],
+} as Meta;
+
+const Template: StoryFn<ComponentProps<typeof ServerList>> = (args) => (
+	<ServerList {...args} />
+);
+
+export const ListOnly = Template.bind({});
+ListOnly.args = {
+	servers: [
+		{
+			id: "1",
+			ownerId: "owner1",
+			name: "Server 1",
+			icon: "https://via.placeholder.com/50",
+		},
+		{
+			id: "2",
+			ownerId: "owner2",
+			name: "Server 2",
+			icon: "https://via.placeholder.com/50",
+		},
+	],
+};
+
+export const WithPlusButton = Template.bind({});
+WithPlusButton.args = {
+	...ListOnly.args,
+	onClickPlus: fn(),
+};

--- a/frontend/src/components/model/server/server-list.tsx
+++ b/frontend/src/components/model/server/server-list.tsx
@@ -1,0 +1,43 @@
+import { joinPaths } from "@tanstack/react-router";
+import { IconButton, IconImage, Text } from "~/components/ui";
+import type { Server } from "~/domains/servers/server";
+import styles from "./server-list.module.scss";
+
+type Props = {
+	servers: Server[];
+	onClickPlus?: () => void;
+};
+
+export const ServerList = ({ servers, onClickPlus }: Props) => {
+	// NOTE: ここにこの関数作るのちょっと違和感あるけど一旦このままで
+	// サーバーへのリンクを生成する
+	const urlToServer = (server: Server) => joinPaths(["/server", server.id]);
+
+	const handleClickPlus = () => {
+		onClickPlus?.();
+	};
+	return (
+		<ul className={styles.root}>
+			{servers.map((server) => (
+				<a key={server.id} href={urlToServer(server)} className={styles.link}>
+					<li className={styles.item}>
+						<IconImage src={server.icon} size="sm" />
+						<Text as="span" size="md">
+							{server.name}
+						</Text>
+					</li>
+				</a>
+			))}
+			{onClickPlus && (
+				<li>
+					<IconButton
+						color="primary"
+						icon="plus"
+						size="lg"
+						onClick={handleClickPlus}
+					/>
+				</li>
+			)}
+		</ul>
+	);
+};

--- a/frontend/src/components/model/server/server-list.tsx
+++ b/frontend/src/components/model/server/server-list.tsx
@@ -8,6 +8,7 @@ type Props = {
 	onClickPlus?: () => void;
 };
 
+// TODO: 余裕があればコンテキストメニューを追加する
 export const ServerList = ({ servers, onClickPlus }: Props) => {
 	// NOTE: ここにこの関数作るのちょっと違和感あるけど一旦このままで
 	// サーバーへのリンクを生成する

--- a/frontend/src/domains/servers/server.ts
+++ b/frontend/src/domains/servers/server.ts
@@ -1,0 +1,6 @@
+export type Server = {
+	id: string;
+	ownerId: string;
+	name: string;
+	icon: string;
+};

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -20,8 +20,8 @@ import { Route as LoginImport } from './routes/login'
 
 const IndexLazyImport = createFileRoute('/')()
 const SpacesSpaceIdLazyImport = createFileRoute('/spaces/$spaceId')()
-const SpacesSpaceIdChannelsChannelIdLazyImport = createFileRoute(
-  '/spaces/$spaceId/channels/$channelId',
+const ServerServerIdChannelsChannelIdLazyImport = createFileRoute(
+  '/server/$serverId/channels/$channelId',
 )()
 
 // Create/Update Routes
@@ -48,12 +48,12 @@ const SpacesSpaceIdLazyRoute = SpacesSpaceIdLazyImport.update({
   import('./routes/spaces.$spaceId.lazy').then((d) => d.Route),
 )
 
-const SpacesSpaceIdChannelsChannelIdLazyRoute =
-  SpacesSpaceIdChannelsChannelIdLazyImport.update({
-    path: '/spaces/$spaceId/channels/$channelId',
+const ServerServerIdChannelsChannelIdLazyRoute =
+  ServerServerIdChannelsChannelIdLazyImport.update({
+    path: '/server/$serverId/channels/$channelId',
     getParentRoute: () => rootRoute,
   } as any).lazy(() =>
-    import('./routes/spaces.$spaceId_.channels.$channelId.lazy').then(
+    import('./routes/server.$serverId_.channels.$channelId.lazy').then(
       (d) => d.Route,
     ),
   )
@@ -90,11 +90,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SpacesSpaceIdLazyImport
       parentRoute: typeof rootRoute
     }
-    '/spaces/$spaceId/channels/$channelId': {
-      id: '/spaces/$spaceId/channels/$channelId'
-      path: '/spaces/$spaceId/channels/$channelId'
-      fullPath: '/spaces/$spaceId/channels/$channelId'
-      preLoaderRoute: typeof SpacesSpaceIdChannelsChannelIdLazyImport
+    '/server/$serverId/channels/$channelId': {
+      id: '/server/$serverId/channels/$channelId'
+      path: '/server/$serverId/channels/$channelId'
+      fullPath: '/server/$serverId/channels/$channelId'
+      preLoaderRoute: typeof ServerServerIdChannelsChannelIdLazyImport
       parentRoute: typeof rootRoute
     }
   }
@@ -107,7 +107,7 @@ export const routeTree = rootRoute.addChildren({
   LoginRoute,
   SampleRoute,
   SpacesSpaceIdLazyRoute,
-  SpacesSpaceIdChannelsChannelIdLazyRoute,
+  ServerServerIdChannelsChannelIdLazyRoute,
 })
 
 /* prettier-ignore-end */
@@ -122,7 +122,7 @@ export const routeTree = rootRoute.addChildren({
         "/login",
         "/sample",
         "/spaces/$spaceId",
-        "/spaces/$spaceId/channels/$channelId"
+        "/server/$serverId/channels/$channelId"
       ]
     },
     "/": {
@@ -137,8 +137,8 @@ export const routeTree = rootRoute.addChildren({
     "/spaces/$spaceId": {
       "filePath": "spaces.$spaceId.lazy.tsx"
     },
-    "/spaces/$spaceId/channels/$channelId": {
-      "filePath": "spaces.$spaceId_.channels.$channelId.lazy.tsx"
+    "/server/$serverId/channels/$channelId": {
+      "filePath": "server.$serverId_.channels.$channelId.lazy.tsx"
     }
   }
 }

--- a/frontend/src/routes/server.$serverId_.channels.$channelId.lazy.tsx
+++ b/frontend/src/routes/server.$serverId_.channels.$channelId.lazy.tsx
@@ -2,7 +2,7 @@ import { createLazyFileRoute } from "@tanstack/react-router";
 import { ChannelDetailPage } from "~/components/page";
 
 export const Route = createLazyFileRoute(
-	"/spaces/$spaceId/channels/$channelId",
+	"/server/$serverId/channels/$channelId",
 )({
 	component: () => <ChannelDetailPage />,
 });


### PR DESCRIPTION
# 概要
- サーバーを一覧表示するコンポーネントを作成
- 追加用ボタンもとりあえず作ったが、処理が無いときは非表示にするようにした
- サーバーのtypeも作成した
  - FEで取り回したいモデルとしてのtypeなので、req, resはAPI接続のとき別途作成

# スクショ
<img width="1018" alt="image" src="https://github.com/givery-bootcamp/dena-2024-team2/assets/38606036/a4347678-e5d2-43aa-bf15-f4cdca7a6666">

# 動作確認
- [ ] （パッケージを追加したので `npm install` を再度したほうがいいかも）
- [ ] http://localhost:6001/?path=/story/components-model-server-serverlist--list-only にアクセスする
- [ ] mockとして用意しているサーバーが表示される
  - [ ] server1
  - [ ] server2
- [ ] http://localhost:6001/?path=/story/components-model-server-serverlist--with-plus-button にアクセスする
- [ ] サーバー一覧の下に追加ボタンが標示されている
- [ ] 追加ボタンをクリックすると、画面下部にあるActionsタブに出力が増える
<img width="310" alt="image" src="https://github.com/givery-bootcamp/dena-2024-team2/assets/38606036/6bdfce00-fdfb-4e74-8d14-68e25d79c322">
