### PR TITLE
Frontend/#11 チャンネル一覧表示コンポーネントの実装

### DIFF
--- a/frontend/src/components/model/channel/channel-list.module.scss
+++ b/frontend/src/components/model/channel/channel-list.module.scss
@@ -1,0 +1,28 @@
+.root {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+}
+
+.link {
+  text-decoration: none;
+  color: var(--c-text-main);
+}
+
+.item {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  border-radius: var(--radius-sm);
+
+  &:hover {
+    background-color: var(--c-gray-50);
+  }
+}
+
+.item__current {
+  background-color: var(--c-cyan-50);
+  color: var(--c-cyan-600);
+}

--- a/frontend/src/components/model/channel/channel-list.stories.tsx
+++ b/frontend/src/components/model/channel/channel-list.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryFn } from "@storybook/react";
+
+import { fn } from "@storybook/test";
+import type { ComponentProps } from "react";
+import { ChannelList } from "./channel-list";
+
+export default {
+	title: "Components/Model/Channel/ChannelList",
+	component: ChannelList,
+	tags: ["autodocs"],
+} as Meta;
+
+const Template: StoryFn<ComponentProps<typeof ChannelList>> = (args) => (
+	<ChannelList {...args} />
+);
+
+export const ListOnly = Template.bind({});
+ListOnly.args = {
+	channels: [
+		{
+			id: 1,
+			serverId: 1,
+			name: "channel 1",
+			createdAt: "2021-01-01T00:00:00.000Z",
+			updatedAt: "2021-01-01T00:00:00.000Z",
+		},
+		{
+			id: 2,
+			serverId: 2,
+			name: "channel 2",
+			createdAt: "2021-01-01T00:00:00.000Z",
+			updatedAt: "2021-01-01T00:00:00.000Z",
+		},
+	],
+};
+
+export const WithPlusButton = Template.bind({});
+WithPlusButton.args = {
+	...ListOnly.args,
+	onClickPlus: fn(),
+};
+
+export const CurrentChannel = Template.bind({});
+CurrentChannel.args = {
+	...ListOnly.args,
+	currentChannelId: 1,
+};

--- a/frontend/src/components/model/channel/channel-list.tsx
+++ b/frontend/src/components/model/channel/channel-list.tsx
@@ -1,0 +1,57 @@
+import clsx from "clsx";
+import { IconButton, Text } from "~/components/ui";
+import type { Channel } from "~/domains/channels";
+import styles from "./channel-list.module.scss";
+
+type Props = {
+	channels: Channel[];
+	currentChannelId?: number;
+	onClickPlus?: () => void;
+};
+
+export const ChannelList = ({
+	channels,
+	currentChannelId,
+	onClickPlus,
+}: Props) => {
+	// NOTE: serverと同じくここにこの関数作るのちょっと違和感あるけど一旦このままで
+	const urlToChannel = (channel: Channel) =>
+		`/servers/${channel.serverId}/channels/${channel.id}`;
+
+	const handleClickPlus = () => {
+		onClickPlus?.();
+	};
+
+	return (
+		<ul className={styles.root}>
+			{channels.map((channel) => (
+				<a
+					key={channel.id}
+					href={urlToChannel(channel)}
+					className={styles.link}
+				>
+					<li
+						className={clsx(
+							styles.item,
+							currentChannelId === channel.id && styles.item__current,
+						)}
+					>
+						<Text as="span" size="md">
+							# {channel.name}
+						</Text>
+					</li>
+				</a>
+			))}
+			{onClickPlus && (
+				<li>
+					<IconButton
+						size="sm"
+						color="inherit"
+						icon="plus"
+						onClick={handleClickPlus}
+					/>
+				</li>
+			)}
+		</ul>
+	);
+};

--- a/frontend/src/global.scss
+++ b/frontend/src/global.scss
@@ -18,6 +18,17 @@
   --c-gray-800: #1a1a1a;
   --c-gray-900: #141414;
 
+  --c-cyan-50: #e0f7fa;
+  --c-cyan-100: #b3ecec;
+  --c-cyan-200: #80e0e3;
+  --c-cyan-300: #4dd2d9;
+  --c-cyan-400: #26c7ce;
+  --c-cyan-500: #4ecdc4;
+  --c-cyan-600: #00a5a5;
+  --c-cyan-700: #008e8e;
+  --c-cyan-800: #007676;
+  --c-cyan-900: #005959;
+
   // radius =============
   --radius-sm: 8px;
   --radius-md: 16px;


### PR DESCRIPTION
# 概要
- チャンネル一覧を表示するコンポーネントを作成

# スクショ
<img width="1027" alt="image" src="https://github.com/givery-bootcamp/dena-2024-team2/assets/38606036/4a52a8ee-bc3c-4a94-a941-0857fc826ba5">

# 動作確認
- [x] http://localhost:6001/?path=/story/components-model-channel-channellist--list-only にアクセスする
- [x] mockとして用意しているchannel一覧が表示される
  - [x] channel 1
  - [x] channel 2
- [x] http://localhost:6001/?path=/story/components-model-channel-channellist--with-plus-button にアクセスする
- [x] 追加用のボタンが表示されていることを確認
- [x] http://localhost:6001/?path=/story/components-model-channel-channellist--current-channel にアクセスする
- [x] channel1の背景色が変わっていることを確認
- [x] 下のコントロールパネルから、currentChannelIdを2にすると、channel2の背景色が変わることを確認
<img width="456" alt="image" src="https://github.com/givery-bootcamp/dena-2024-team2/assets/38606036/977734c0-6e35-44e6-a563-2b04ca1f7ae1">
