### PR TITLE
userサーバーで発行されたjwtを検証&利用できるように認証の処理を修正した

### DIFF
--- a/backend/timeline/internal/config/config.go
+++ b/backend/timeline/internal/config/config.go
@@ -13,6 +13,7 @@ var DBUserName = "root"
 var DBPassword = ""
 var DBPort = 3306
 var DBName = "training"
+var JWTSecret = ""
 
 func init() {
 	if v := os.Getenv("HOSTNAME"); v != "" {
@@ -38,5 +39,8 @@ func init() {
 	}
 	if v := os.Getenv("DB_NAME"); v != "" {
 		DBName = v
+	}
+	if v := os.Getenv("JWT_SECRET"); v != "" {
+		JWTSecret = v
 	}
 }

--- a/backend/timeline/internal/controllers/controller_helper.go
+++ b/backend/timeline/internal/controllers/controller_helper.go
@@ -21,6 +21,6 @@ func handleError(ctx *gin.Context, status int, err error) {
 	ctx.JSON(status, &res)
 }
 
-func getUserIdFromContext(ctx *gin.Context) uint {
-	return ctx.MustGet("uid").(uint)
+func getUserIdFromContext(ctx *gin.Context) int {
+	return ctx.MustGet("uid").(int)
 }

--- a/backend/timeline/internal/infrastructures/jwt.go
+++ b/backend/timeline/internal/infrastructures/jwt.go
@@ -3,22 +3,21 @@ package infrastructures
 import (
 	"fmt"
 	"log"
+	"strconv"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
 )
 
-var secretKey = []byte("secret")
+var secretKey = []byte("ultra_super_ultimate_secret")
 
 type CustomClaims struct {
-	UserId uint
 	jwt.RegisteredClaims
 }
 
 func GenerateToken(userId uint) (string, error) {
 	claims := CustomClaims{
-		userId,
 		jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(time.Now().Add(24 * time.Hour)),
 			IssuedAt:  jwt.NewNumericDate(time.Now()),
@@ -39,7 +38,7 @@ func GenerateToken(userId uint) (string, error) {
 	return signedToken, nil
 }
 
-func VerifyToken(token string) (uint, error) {
+func VerifyToken(token string) (int, error) {
 	parsedToken, err := jwt.ParseWithClaims(token, &CustomClaims{}, func(token *jwt.Token) (interface{}, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
@@ -53,7 +52,11 @@ func VerifyToken(token string) (uint, error) {
 	}
 
 	if claims, ok := parsedToken.Claims.(*CustomClaims); ok {
-		return claims.UserId, nil
+		uid, err := strconv.Atoi(claims.Subject)
+		if err != nil {
+			return 0, err
+		}
+		return uid, nil
 	} else {
 		log.Fatal("unknown claims type, cannot proceed")
 		return 0, fmt.Errorf("failed to convert token to customClaims")

--- a/backend/timeline/internal/infrastructures/jwt.go
+++ b/backend/timeline/internal/infrastructures/jwt.go
@@ -3,14 +3,13 @@ package infrastructures
 import (
 	"fmt"
 	"log"
+	"myapp/internal/config"
 	"strconv"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
 )
-
-var secretKey = []byte("ultra_super_ultimate_secret")
 
 type CustomClaims struct {
 	jwt.RegisteredClaims
@@ -29,7 +28,7 @@ func GenerateToken(userId uint) (string, error) {
 		},
 	}
 	unsignedToken := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-	signedToken, err := unsignedToken.SignedString(secretKey)
+	signedToken, err := unsignedToken.SignedString([]byte(config.JWTSecret))
 	if err != nil {
 		log.Printf("%v", err)
 		return "", err
@@ -44,7 +43,7 @@ func VerifyToken(token string) (int, error) {
 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 		}
 
-		return secretKey, nil
+		return []byte(config.JWTSecret), nil
 	})
 
 	if err != nil {

--- a/backend/timeline/internal/middleware/auth.go
+++ b/backend/timeline/internal/middleware/auth.go
@@ -1,17 +1,15 @@
 package middleware
 
 import (
-	"fmt"
 	"myapp/internal/infrastructures"
 	"net/http"
-	"strings"
 
 	"github.com/gin-gonic/gin"
 )
 
 func Auth() gin.HandlerFunc {
 	return func(ctx *gin.Context) {
-		jwtToken, err := extractBearerToken(ctx.GetHeader("Authorization"))
+		jwtToken, err := ctx.Cookie("training-jwt")
 		if err != nil {
 			ctx.AbortWithStatusJSON(http.StatusUnauthorized, err.Error())
 			return
@@ -25,17 +23,4 @@ func Auth() gin.HandlerFunc {
 
 		ctx.Next()
 	}
-}
-
-func extractBearerToken(headerString string) (string, error) {
-	if headerString == "" {
-		return "", fmt.Errorf("required header is empty")
-	}
-
-	jwtToken := strings.Split(headerString, " ")
-	if len(jwtToken) != 2 {
-		return "", fmt.Errorf("authorization header requires Bearer before token: see https://jwt.io/introduction")
-	}
-
-	return jwtToken[1], nil
 }

--- a/backend/timeline/internal/repositories/server_repository.go
+++ b/backend/timeline/internal/repositories/server_repository.go
@@ -31,8 +31,8 @@ func (r *ServerRepository) Get(serverId int) (*entities.Server, error) {
 	return server, nil
 }
 
-func (r *ServerRepository) Create(ctx *gin.Context, name string, icon string, uid uint) (*entities.Server, error) {
-	server := entities.Server{OwnerId: int(uid), Name: name, Icon: icon}
+func (r *ServerRepository) Create(ctx *gin.Context, name string, icon string, uid int) (*entities.Server, error) {
+	server := entities.Server{OwnerId: uid, Name: name, Icon: icon}
 	result := r.Conn.Omit("DeletedAt").Create(&server)
 	if result.Error != nil {
 		return nil, result.Error

--- a/backend/timeline/internal/usecases/create_server_usecase.go
+++ b/backend/timeline/internal/usecases/create_server_usecase.go
@@ -13,7 +13,7 @@ func NewCreateServerUsecase() *CreateServerUsecase {
 	return &CreateServerUsecase{}
 }
 
-func (uc *CreateServerUsecase) Execute(ctx *gin.Context, name string, icon string, uid uint) (*entities.Server, error) {
+func (uc *CreateServerUsecase) Execute(ctx *gin.Context, name string, icon string, uid int) (*entities.Server, error) {
 	serverRepo := repositories.NewGetServerRepository(DB(ctx))
 	server, err := serverRepo.Create(ctx, name, icon, uid)
 	if err != nil {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
         condition: service_healthy
     environment:
       TZ: Asia/Tokyo
+      JWT_SECRET: ultra_super_ultimate_secret
   backend-user:
     image: gradle:8.8.0-jdk21-jammy
     command: "gradle run"


### PR DESCRIPTION
### やったこと
kotlinサーバーで発行されたjwtについても検証できるように修正した。


### 動作確認
kotlinサーバーにsigninする
```
curl -X POST -H "Content-Type: application/json" -d '{"name":"ozaki","password":"password"}' http://localhost:9090/user/signin -c cookie.txt                                                                                                                                                                                                                       
```
→{"id":5,"name":"ozaki"}%     

cookie.txtに保存してあるjwtを使って、Authorizationヘッダーに貼り付ける
```
curl -X POST -H "Content-Type: application/json" -d '{"name":"name3","icon":"icon2"}' -H 'Authorization:Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI1IiwiaXNzIjoiS29kZWUiLCJpYXQiOjE3MTk0NjMxMDIsImV4cCI6MTcxOTQ2NjcwMiwidXNlcm5hbWUiOiJvemFraSJ9.kQeOesf2zxXI4qqRH9eDY244N-8diEjVkwP7tULN8Ok' http://localhost:9000/servers
```
→レスポンスが 200で返ってくる