### PR TITLE
チャンネルを作成する API の id のアップデート

### DIFF
--- a/backend/timeline/internal/controllers/create_channel_controller.go
+++ b/backend/timeline/internal/controllers/create_channel_controller.go
@@ -17,7 +17,7 @@ type createChannelsRequestParam struct {
 
 func CreateChannels(ctx *gin.Context) {
 	var param createChannelsRequestParam
-	serverId, err := strconv.Atoi(ctx.Param("id"))
+	serverId, err := strconv.Atoi(ctx.Param("serverId"))
 	if err != nil {
 		ctx.JSON(http.StatusBadRequest, err.Error())
 	}

--- a/backend/timeline/internal/middleware/router.go
+++ b/backend/timeline/internal/middleware/router.go
@@ -18,7 +18,7 @@ func SetupRoutes(app *gin.Engine) {
 	{
 		authorized.GET("/servers", controllers.GetServers)
 		authorized.GET("/channels", controllers.GetChannels)
-		authorized.POST("/servers/:id/channels", controllers.CreateChannels)
+		authorized.POST("/servers/:serverId/channels", controllers.CreateChannels)
 		authorized.GET("/channels/:id/posts", controllers.GetPosts)
 		authorized.POST("/channels/:id/posts", controllers.CreatePost)
 		authorized.POST("/servers", controllers.CreateServer)


### PR DESCRIPTION
## 動作確認
**前提：サインインして jwt をコピーしておく**
```
curl -H POST 'localhost:9000/servers/1/channels' -H 'Content-Type: application/json' -d '{"name" : "channel3"}' -b "training-jwt=<<トークン>>"
```
レスポンス
```
{"id":3,"serverId":1,"name":"channel3","createdAt":"2024-06-27T17:04:14.444+09:00"}% 
```

### DB を確認する場合
```
% docker-compose exec db mysql training
```

```
mysql> select * from channels;
+----+-----------+----------+---------------------+---------------------+------------+
| id | server_id | name     | created_at          | updated_at          | deleted_at |
+----+-----------+----------+---------------------+---------------------+------------+
|  1 |         1 | channel1 | 2024-06-27 11:30:19 | 2024-06-27 11:30:19 | NULL       |
|  2 |         1 | channel2 | 2024-06-27 11:30:19 | 2024-06-27 11:30:19 | NULL       |
|  3 |         1 | channel3 | 2024-06-27 17:04:14 | 2024-06-27 17:04:14 | NULL       |
+----+-----------+----------+---------------------+---------------------+------------+
3 rows in set (0.00 sec)
```