### PR TITLE
投稿を作成する API の改修

### DIFF
--- a/backend/timeline/internal/controllers/create_post_controller.go
+++ b/backend/timeline/internal/controllers/create_post_controller.go
@@ -16,7 +16,11 @@ type createPostRequestParams struct {
 
 func CreatePost(ctx *gin.Context) {
 	var post createPostRequestParams
-	channelId, err := strconv.Atoi(ctx.Param("id"))
+	serverId, err := strconv.Atoi(ctx.Param("serverId"))
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, err.Error())
+	}
+	channelId, err := strconv.Atoi(ctx.Param("channelId"))
 	if err != nil {
 		ctx.JSON(http.StatusBadRequest, err.Error())
 	}
@@ -26,9 +30,11 @@ func CreatePost(ctx *gin.Context) {
 		return
 	}
 
-	repository := repositories.NewCreatePostRepository(DB(ctx))
-	usecase := usecases.NewCreatePostUsecase(repository)
-	result, err := usecase.Execute(post.UserId, channelId, post.Content)
+	createPostRepository := repositories.NewCreatePostRepository(DB(ctx))
+	serverRepository := repositories.NewGetServerRepository(DB(ctx))
+	channelRepository := repositories.NewGetChannelRepository(DB(ctx))
+	usecase := usecases.NewCreatePostUsecase(createPostRepository, serverRepository, channelRepository)
+	result, err := usecase.Execute(post.UserId, serverId, channelId, post.Content)
 	if err != nil {
 		handleError(ctx, 500, err)
 		return

--- a/backend/timeline/internal/interfaces/channel_repository.go
+++ b/backend/timeline/internal/interfaces/channel_repository.go
@@ -1,0 +1,7 @@
+package interfaces
+
+import "myapp/internal/entities"
+
+type ChannelRepository interface {
+	Get(channelId int) (*entities.Channel, error)
+}

--- a/backend/timeline/internal/middleware/router.go
+++ b/backend/timeline/internal/middleware/router.go
@@ -20,7 +20,7 @@ func SetupRoutes(app *gin.Engine) {
 		authorized.GET("/servers/:serverId/channels", controllers.GetChannels)
 		authorized.POST("/servers/:serverId/channels", controllers.CreateChannels)
 		authorized.GET("/channels/:id/posts", controllers.GetPosts)
-		authorized.POST("servers/:serverId/channels/:channelId/posts", controllers.CreatePost)
+		authorized.POST("/servers/:serverId/channels/:channelId/posts", controllers.CreatePost)
 		authorized.POST("/servers", controllers.CreateServer)
 	}
 }

--- a/backend/timeline/internal/middleware/router.go
+++ b/backend/timeline/internal/middleware/router.go
@@ -20,7 +20,7 @@ func SetupRoutes(app *gin.Engine) {
 		authorized.GET("/channels", controllers.GetChannels)
 		authorized.POST("/servers/:id/channels", controllers.CreateChannels)
 		authorized.GET("/channels/:id/posts", controllers.GetPosts)
-		authorized.POST("/channels/:id/posts", controllers.CreatePost)
+		authorized.POST("servers/:serverId/channels/:channelId/posts", controllers.CreatePost)
 		authorized.POST("/servers", controllers.CreateServer)
 	}
 }

--- a/backend/timeline/internal/usecases/create_post_usercase.go
+++ b/backend/timeline/internal/usecases/create_post_usercase.go
@@ -6,15 +6,28 @@ import (
 )
 
 type CreatePostUsecase struct {
-	repository interfaces.CreatePostRepository
+	createPostRepository interfaces.CreatePostRepository
+	serverRepository     interfaces.ServerRepository
+	channelRepository    interfaces.ChannelRepository
 }
 
-func NewCreatePostUsecase(r interfaces.CreatePostRepository) *CreatePostUsecase {
+func NewCreatePostUsecase(cpr interfaces.CreatePostRepository, sr interfaces.ServerRepository, cr interfaces.ChannelRepository) *CreatePostUsecase {
 	return &CreatePostUsecase{
-		repository: r,
+		createPostRepository: cpr,
+		serverRepository:     sr,
+		channelRepository:    cr,
 	}
 }
 
-func (u *CreatePostUsecase) Execute(userID int, channelID int, content string) (*entities.Post, error) {
-	return u.repository.Post(userID, channelID, content)
+func (u *CreatePostUsecase) Execute(userID int, serverID int, channelID int, content string) (*entities.Post, error) {
+	// 存在しているサーバーか確認する
+	if _, err := u.serverRepository.Get(serverID); err != nil {
+		return nil, err
+	}
+
+	if _, err := u.channelRepository.Get(channelID); err != nil {
+		return nil, err
+	}
+
+	return u.createPostRepository.Post(userID, channelID, content)
 }


### PR DESCRIPTION
closes #62 

## 概要
- 投稿を作成する API の改修：`/servers/:serverId/channels/:channelId/posts`
- create_repository.go の interfaces を流れで作りました。
  - 若干、この PR とズレちゃうけど。

## 動作確認
**前提：サインインして jwt をコピーしておく**
```
curl -H POST 'localhost:9000/servers/1/channels/1/posts' -H 'Content-Type: application/json' -d '{"user_id": 1, "content" : "ワイワイ"}' -b "training-jwt=<<トークン>>"
```
レスポンス
```
{"id":3,"channel_id":1,"User":{"Id":1,"Name":""},"content":"ワイワイ","created_at":"2024-06-28T11:06:23.33+09:00","updated_at":"2024-06-28T11:06:23.33+09:00","deleted_at":null}
```

### DB を確認する場合
```
% docker-compose exec db mysql training
```

```
mysql> select * from posts;
+----+---------+------------+----------------+---------------------+---------------------+------------+
| id | user_id | channel_id | content        | created_at          | updated_at          | deleted_at |
+----+---------+------------+----------------+---------------------+---------------------+------------+
|  1 |       1 |          1 | 質問1
改行     | 2024-06-27 18:33:11 | 2024-06-27 18:33:11 | NULL       |
|  2 |       1 |          1 | 質問2
改行     | 2024-06-27 18:33:11 | 2024-06-27 18:33:11 | NULL       |
|  3 |       1 |          1 | ワイワイ       | 2024-06-28 11:06:23 | 2024-06-28 11:06:23 | NULL       |
+----+---------+------------+----------------+---------------------+---------------------+------------+
3 rows in set (0.00 sec)
```