### PR TITLE
Frontend/#79 date-utilsの実装

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
 				"@tanstack/react-query": "^5.45.1",
 				"@tanstack/react-router": "^1.38.1",
 				"clsx": "^2.1.1",
+				"date-fns": "^3.6.0",
 				"ky": "^1.3.0",
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
@@ -7214,6 +7215,22 @@
 				"react-dom": ">=16.8"
 			}
 		},
+		"node_modules/@tanstack/router-devtools/node_modules/date-fns": {
+			"version": "2.30.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+			"integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.21.0"
+			},
+			"engines": {
+				"node": ">=0.11"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/date-fns"
+			}
+		},
 		"node_modules/@tanstack/router-generator": {
 			"version": "1.37.0",
 			"resolved": "https://registry.npmjs.org/@tanstack/router-generator/-/router-generator-1.37.0.tgz",
@@ -9201,19 +9218,12 @@
 			"dev": true
 		},
 		"node_modules/date-fns": {
-			"version": "2.30.0",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
-			"integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
-			"dev": true,
-			"dependencies": {
-				"@babel/runtime": "^7.21.0"
-			},
-			"engines": {
-				"node": ">=0.11"
-			},
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+			"integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
 			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/date-fns"
+				"type": "github",
+				"url": "https://github.com/sponsors/kossnocorp"
 			}
 		},
 		"node_modules/debug": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
 		"@tanstack/react-query": "^5.45.1",
 		"@tanstack/react-router": "^1.38.1",
 		"clsx": "^2.1.1",
+		"date-fns": "^3.6.0",
 		"ky": "^1.3.0",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",

--- a/frontend/src/utils/date-utils/date-utils.test.ts
+++ b/frontend/src/utils/date-utils/date-utils.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { formatDateTime } from "./date-utils";
+
+describe("formatDateTime", () => {
+	describe("正しいフォーマットが指定された場合", () => {
+		describe("時間まで指定された場合", () => {
+			it("Dateが yyyy-MM-dd HH:mm:ss 形式でフォーマットされる", () => {
+				const date = new Date("2022-01-01T12:34:56");
+				const format = "yyyy-MM-dd HH:mm:ss";
+				const expected = "2022-01-01 12:34:56";
+				const result = formatDateTime(date, format);
+				expect(result).toEqual(expected);
+			});
+		});
+		describe("日付までの指定だった場合", () => {
+			it("Dateが yyyy/MM/dd 形式でフォーマットされる", () => {
+				const date = new Date("2022-01-01T12:34:56");
+				const format = "yyyy/MM/dd";
+				const expected = "2022/01/01";
+				const result = formatDateTime(date, format);
+				expect(result).toEqual(expected);
+			});
+		});
+	});
+
+	describe("不正なフォーマットが指定された場合", () =>
+		it("エラーがスローされる", () => {
+			const date = new Date("2022-01-01T12:34:56");
+			const format = "invalid";
+			expect(() => formatDateTime(date, format)).toThrow();
+		}));
+});

--- a/frontend/src/utils/date-utils/date-utils.ts
+++ b/frontend/src/utils/date-utils/date-utils.ts
@@ -1,0 +1,5 @@
+import { formatDate } from "date-fns";
+
+export const formatDateTime = (date: Date, format: string): string => {
+	return formatDate(date, format);
+};

--- a/frontend/src/utils/date-utils/index.ts
+++ b/frontend/src/utils/date-utils/index.ts
@@ -1,0 +1,1 @@
+export { formatDateTime } from "./date-utils";


### PR DESCRIPTION
# 概要
- 日時系の処理をまとめた date-utilsを作成
- 今回は一旦formatのみを実装
  - date-fnsを使った

# 動作確認
- [ ] テストが通っていることを確認する
```
# コンテナに向けてやる場合
$ docker compose exec frontend npm run test
```