### PR TITLE
Frontend/#11 投稿一覧コンポーネントの作成

### DIFF
--- a/frontend/src/components/model/posts/index.ts
+++ b/frontend/src/components/model/posts/index.ts
@@ -1,1 +1,2 @@
 export { PostCard } from "./post-card";
+export { PostList } from "./post-list";

--- a/frontend/src/components/model/posts/post-list.module.scss
+++ b/frontend/src/components/model/posts/post-list.module.scss
@@ -1,0 +1,6 @@
+.list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+}

--- a/frontend/src/components/model/posts/post-list.stories.tsx
+++ b/frontend/src/components/model/posts/post-list.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryFn } from "@storybook/react";
+
+import type { ComponentProps } from "react";
+import { PostList } from "./post-list";
+
+export default {
+	title: "Components/Model/Posts/PostList",
+	component: PostList,
+	tags: ["autodocs"],
+} as Meta;
+
+const Template: StoryFn<ComponentProps<typeof PostList>> = (args) => (
+	<PostList {...args} />
+);
+
+export const Default = Template.bind({});
+Default.args = {
+	posts: [
+		{
+			id: 1,
+			channelId: 1,
+			user: {
+				id: 1,
+				name: "John Doe",
+			},
+			content: "This is a post",
+			createdAt: "2024-06-26T17:31:15+09:00",
+		},
+		{
+			id: 2,
+			channelId: 1,
+			user: {
+				id: 2,
+				name: "Jane Doe",
+			},
+			content: "This is another post",
+			createdAt: "2024-06-26T17:31:15+09:00",
+		},
+	],
+};

--- a/frontend/src/components/model/posts/post-list.tsx
+++ b/frontend/src/components/model/posts/post-list.tsx
@@ -1,0 +1,19 @@
+import type { Post } from "~/domains/posts";
+import { PostCard } from "./post-card";
+import styles from "./post-list.module.scss";
+
+type Props = {
+	posts: Post[];
+};
+
+export const PostList = ({ posts }: Props) => {
+	return (
+		<ul className={styles.list}>
+			{posts.map((post) => (
+				<li key={post.id}>
+					<PostCard post={post} />
+				</li>
+			))}
+		</ul>
+	);
+};


### PR DESCRIPTION
# 概要
- 投稿を一覧表示するコンポーネントを作成

# スクショ
<img width="1028" alt="image" src="https://github.com/givery-bootcamp/dena-2024-team2/assets/38606036/3a37ddea-48f8-4335-8a37-418c17d9ecc7">


# 動作確認
- [x] http://localhost:6001/?path=/docs/components-model-posts-postlist--docs にアクセス
- [x] 投稿一覧コンポーネントが表示されることを確認
- [x] 投稿をホバーすると背景色が変わることを確認