### PR TITLE
Frontend/#95 サーバー一覧ページのUIを作成

### DIFF
--- a/frontend/src/components/page/index.ts
+++ b/frontend/src/components/page/index.ts
@@ -1,3 +1,4 @@
 export { ChannelDetailPage } from "./channel-detail";
 export { SpaceDetailPage } from "./space-detail";
 export { LoginPage } from "./login";
+export { ServersPage } from "./servers";

--- a/frontend/src/components/page/servers/index.ts
+++ b/frontend/src/components/page/servers/index.ts
@@ -1,0 +1,1 @@
+export { ServersPage } from "./servers";

--- a/frontend/src/components/page/servers/mock.ts
+++ b/frontend/src/components/page/servers/mock.ts
@@ -1,0 +1,18 @@
+import type { Server } from "~/domains/servers";
+
+export const mock = {
+	servers: [
+		{
+			id: "1",
+			ownerId: "1",
+			name: "My Server",
+			icon: "https://via.placeholder.com/50",
+		},
+		{
+			id: "2",
+			ownerId: "1",
+			name: "Another Server",
+			icon: "https://via.placeholder.com/50",
+		},
+	],
+} as { servers: Server[] };

--- a/frontend/src/components/page/servers/servers.module.scss
+++ b/frontend/src/components/page/servers/servers.module.scss
@@ -1,0 +1,10 @@
+.root {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem;
+}
+
+.card {
+  width: 20rem;
+}

--- a/frontend/src/components/page/servers/servers.tsx
+++ b/frontend/src/components/page/servers/servers.tsx
@@ -1,0 +1,21 @@
+import { ServerList } from "~/components/model/server";
+import { Card, Text } from "~/components/ui";
+import { mock } from "./mock";
+import styles from "./servers.module.scss";
+
+export const ServersPage = () => {
+	return (
+		<div className={styles.root}>
+			<div className={styles.card}>
+				<Card
+					header={
+						<Text as="h2" size="lg" bold>
+							🪐 Servers
+						</Text>
+					}
+					body={<ServerList servers={mock.servers} />}
+				/>
+			</div>
+		</div>
+	);
+};

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -18,13 +18,18 @@ import { Route as LoginImport } from './routes/login'
 
 // Create Virtual Routes
 
+const ServersLazyImport = createFileRoute('/servers')()
 const IndexLazyImport = createFileRoute('/')()
-const SpacesSpaceIdLazyImport = createFileRoute('/spaces/$spaceId')()
 const ServersServerIdChannelsChannelIdLazyImport = createFileRoute(
   '/servers/$serverId/channels/$channelId',
 )()
 
 // Create/Update Routes
+
+const ServersLazyRoute = ServersLazyImport.update({
+  path: '/servers',
+  getParentRoute: () => rootRoute,
+} as any).lazy(() => import('./routes/servers.lazy').then((d) => d.Route))
 
 const SampleRoute = SampleImport.update({
   path: '/sample',
@@ -41,17 +46,10 @@ const IndexLazyRoute = IndexLazyImport.update({
   getParentRoute: () => rootRoute,
 } as any).lazy(() => import('./routes/index.lazy').then((d) => d.Route))
 
-const SpacesSpaceIdLazyRoute = SpacesSpaceIdLazyImport.update({
-  path: '/spaces/$spaceId',
-  getParentRoute: () => rootRoute,
-} as any).lazy(() =>
-  import('./routes/spaces.$spaceId.lazy').then((d) => d.Route),
-)
-
 const ServersServerIdChannelsChannelIdLazyRoute =
   ServersServerIdChannelsChannelIdLazyImport.update({
-    path: '/servers/$serverId/channels/$channelId',
-    getParentRoute: () => rootRoute,
+    path: '/$serverId/channels/$channelId',
+    getParentRoute: () => ServersLazyRoute,
   } as any).lazy(() =>
     import('./routes/servers.$serverId.channels.$channelId.lazy').then(
       (d) => d.Route,
@@ -83,19 +81,19 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SampleImport
       parentRoute: typeof rootRoute
     }
-    '/spaces/$spaceId': {
-      id: '/spaces/$spaceId'
-      path: '/spaces/$spaceId'
-      fullPath: '/spaces/$spaceId'
-      preLoaderRoute: typeof SpacesSpaceIdLazyImport
+    '/servers': {
+      id: '/servers'
+      path: '/servers'
+      fullPath: '/servers'
+      preLoaderRoute: typeof ServersLazyImport
       parentRoute: typeof rootRoute
     }
     '/servers/$serverId/channels/$channelId': {
       id: '/servers/$serverId/channels/$channelId'
-      path: '/servers/$serverId/channels/$channelId'
+      path: '/$serverId/channels/$channelId'
       fullPath: '/servers/$serverId/channels/$channelId'
       preLoaderRoute: typeof ServersServerIdChannelsChannelIdLazyImport
-      parentRoute: typeof rootRoute
+      parentRoute: typeof ServersLazyImport
     }
   }
 }
@@ -106,8 +104,9 @@ export const routeTree = rootRoute.addChildren({
   IndexLazyRoute,
   LoginRoute,
   SampleRoute,
-  SpacesSpaceIdLazyRoute,
-  ServersServerIdChannelsChannelIdLazyRoute,
+  ServersLazyRoute: ServersLazyRoute.addChildren({
+    ServersServerIdChannelsChannelIdLazyRoute,
+  }),
 })
 
 /* prettier-ignore-end */
@@ -121,8 +120,7 @@ export const routeTree = rootRoute.addChildren({
         "/",
         "/login",
         "/sample",
-        "/spaces/$spaceId",
-        "/servers/$serverId/channels/$channelId"
+        "/servers"
       ]
     },
     "/": {
@@ -134,11 +132,15 @@ export const routeTree = rootRoute.addChildren({
     "/sample": {
       "filePath": "sample.tsx"
     },
-    "/spaces/$spaceId": {
-      "filePath": "spaces.$spaceId.lazy.tsx"
+    "/servers": {
+      "filePath": "servers.lazy.tsx",
+      "children": [
+        "/servers/$serverId/channels/$channelId"
+      ]
     },
     "/servers/$serverId/channels/$channelId": {
-      "filePath": "servers.$serverId.channels.$channelId.lazy.tsx"
+      "filePath": "servers.$serverId.channels.$channelId.lazy.tsx",
+      "parent": "/servers"
     }
   }
 }

--- a/frontend/src/routes/servers.lazy.tsx
+++ b/frontend/src/routes/servers.lazy.tsx
@@ -1,0 +1,6 @@
+import { createLazyFileRoute } from "@tanstack/react-router";
+import { ServersPage } from "~/components/page";
+
+export const Route = createLazyFileRoute("/servers")({
+	component: () => <ServersPage />,
+});

--- a/frontend/src/routes/spaces.$spaceId.lazy.tsx
+++ b/frontend/src/routes/spaces.$spaceId.lazy.tsx
@@ -1,6 +1,0 @@
-import { createLazyFileRoute } from "@tanstack/react-router";
-import { SpaceDetailPage } from "~/components/page";
-
-export const Route = createLazyFileRoute("/spaces/$spaceId")({
-	component: () => <SpaceDetailPage />,
-});


### PR DESCRIPTION
# 概要
- サーバー一覧ページのUIを作成

# スクショ
<img width="1681" alt="image" src="https://github.com/givery-bootcamp/dena-2024-team2/assets/38606036/c7ef445a-6c0a-4722-92a0-478d566842a2">


# 動作確認
- [ ] http://localhost:3000/servers にアクセスする
- [ ] mockとして用意されているサーバー一覧が表示されることを確認
  - APIの接続は別PR