### PR TITLE
投稿作成 API：ユーザー情報を jwt から取得する

### DIFF
--- a/backend/timeline/internal/controllers/controller_helper.go
+++ b/backend/timeline/internal/controllers/controller_helper.go
@@ -24,3 +24,7 @@ func handleError(ctx *gin.Context, status int, err error) {
 func getUserIdFromContext(ctx *gin.Context) int {
 	return ctx.MustGet("uid").(int)
 }
+
+func getUserNameFromContext(ctx *gin.Context) string {
+	return ctx.MustGet("userName").(string)
+}

--- a/backend/timeline/internal/controllers/create_post_controller.go
+++ b/backend/timeline/internal/controllers/create_post_controller.go
@@ -10,7 +10,6 @@ import (
 )
 
 type createPostRequestParams struct {
-	UserId  int    `json:"user_id"`
 	Content string `json:"content"`
 }
 
@@ -30,11 +29,13 @@ func CreatePost(ctx *gin.Context) {
 		return
 	}
 
+	uid := getUserIdFromContext(ctx)
+
 	createPostRepository := repositories.NewCreatePostRepository(DB(ctx))
 	serverRepository := repositories.NewGetServerRepository(DB(ctx))
 	channelRepository := repositories.NewGetChannelRepository(DB(ctx))
 	usecase := usecases.NewCreatePostUsecase(createPostRepository, serverRepository, channelRepository)
-	result, err := usecase.Execute(post.UserId, serverId, channelId, post.Content)
+	result, err := usecase.Execute(uid, serverId, channelId, post.Content)
 	if err != nil {
 		handleError(ctx, 500, err)
 		return

--- a/backend/timeline/internal/controllers/create_post_controller.go
+++ b/backend/timeline/internal/controllers/create_post_controller.go
@@ -29,7 +29,8 @@ func CreatePost(ctx *gin.Context) {
 		return
 	}
 
-	uid := getUserIdFromContext(ctx)
+	userId := getUserIdFromContext(ctx)
+	userName := getUserNameFromContext(ctx)
 
 	createPostRepository := repositories.NewCreatePostRepository(DB(ctx))
 	serverRepository := repositories.NewGetServerRepository(DB(ctx))

--- a/backend/timeline/internal/controllers/create_post_controller.go
+++ b/backend/timeline/internal/controllers/create_post_controller.go
@@ -1,10 +1,12 @@
 package controllers
 
 import (
+	"myapp/internal/entities"
 	"myapp/internal/repositories"
 	"myapp/internal/usecases"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/gin-gonic/gin"
 )
@@ -41,5 +43,25 @@ func CreatePost(ctx *gin.Context) {
 		handleError(ctx, 500, err)
 		return
 	}
-	ctx.JSON(200, result)
+	ctx.JSON(200, newPostConvertToJson(result))
+}
+
+func newPostConvertToJson(v *entities.Post) newPostJson {
+	return newPostJson{
+		Id:        v.Id,
+		ChannelId: v.ChannelId,
+		UserId:    v.User.Id,
+		UserName:  v.User.Name,
+		Content:   v.Content,
+		CreatedAt: v.CreatedAt,
+	}
+}
+
+type newPostJson struct {
+	Id        int       `json:"id"`
+	ChannelId int       `json:"channel_id"`
+	UserId    int       `json:"user_id"`
+	UserName  string    `json:"user_name"`
+	Content   string    `json:"content"`
+	CreatedAt time.Time `json:"created_at"`
 }

--- a/backend/timeline/internal/controllers/create_post_controller.go
+++ b/backend/timeline/internal/controllers/create_post_controller.go
@@ -35,7 +35,7 @@ func CreatePost(ctx *gin.Context) {
 	serverRepository := repositories.NewGetServerRepository(DB(ctx))
 	channelRepository := repositories.NewGetChannelRepository(DB(ctx))
 	usecase := usecases.NewCreatePostUsecase(createPostRepository, serverRepository, channelRepository)
-	result, err := usecase.Execute(uid, serverId, channelId, post.Content)
+	result, err := usecase.Execute(serverId, channelId, userId, userName, post.Content)
 	if err != nil {
 		handleError(ctx, 500, err)
 		return

--- a/backend/timeline/internal/infrastructures/jwt.go
+++ b/backend/timeline/internal/infrastructures/jwt.go
@@ -54,11 +54,10 @@ func VerifyToken(token string) (int, string, error) {
 
 	if claims, ok := parsedToken.Claims.(*CustomClaims); ok {
 		uid, err := strconv.Atoi(claims.Subject)
+		userName := claims.UserName
 		if err != nil {
 			return 0, "", err
 		}
-
-		userName := claims.UserName
 
 		return uid, userName, nil
 	} else {

--- a/backend/timeline/internal/infrastructures/jwt.go
+++ b/backend/timeline/internal/infrastructures/jwt.go
@@ -13,6 +13,7 @@ import (
 
 type CustomClaims struct {
 	jwt.RegisteredClaims
+	UserName string
 }
 
 func GenerateToken(userId uint) (string, error) {
@@ -26,6 +27,7 @@ func GenerateToken(userId uint) (string, error) {
 			ID:        uuid.New().String(),
 			Audience:  []string{},
 		},
+		"",
 	}
 	unsignedToken := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	signedToken, err := unsignedToken.SignedString([]byte(config.JWTSecret))
@@ -37,7 +39,7 @@ func GenerateToken(userId uint) (string, error) {
 	return signedToken, nil
 }
 
-func VerifyToken(token string) (int, error) {
+func VerifyToken(token string) (int, string, error) {
 	parsedToken, err := jwt.ParseWithClaims(token, &CustomClaims{}, func(token *jwt.Token) (interface{}, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
@@ -47,17 +49,20 @@ func VerifyToken(token string) (int, error) {
 	})
 
 	if err != nil {
-		return 0, err
+		return 0, "", err
 	}
 
 	if claims, ok := parsedToken.Claims.(*CustomClaims); ok {
 		uid, err := strconv.Atoi(claims.Subject)
 		if err != nil {
-			return 0, err
+			return 0, "", err
 		}
-		return uid, nil
+
+		userName := claims.UserName
+
+		return uid, userName, nil
 	} else {
 		log.Fatal("unknown claims type, cannot proceed")
-		return 0, fmt.Errorf("failed to convert token to customClaims")
+		return 0, "", fmt.Errorf("failed to convert token to customClaims")
 	}
 }

--- a/backend/timeline/internal/interfaces/create_post_repository.go
+++ b/backend/timeline/internal/interfaces/create_post_repository.go
@@ -5,5 +5,5 @@ import (
 )
 
 type CreatePostRepository interface {
-	Post(userID int, channelID int, content string) (*entities.Post, error)
+	Post(channelID int, userID int, userName string, content string) (*entities.Post, error)
 }

--- a/backend/timeline/internal/middleware/auth.go
+++ b/backend/timeline/internal/middleware/auth.go
@@ -14,8 +14,9 @@ func Auth() gin.HandlerFunc {
 			ctx.AbortWithStatusJSON(http.StatusUnauthorized, err.Error())
 			return
 		}
-		uid, err := infrastructures.VerifyToken(jwtToken)
+		uid, userName, err := infrastructures.VerifyToken(jwtToken)
 		ctx.Set("uid", uid)
+		ctx.Set("userName", userName)
 		if err != nil {
 			ctx.AbortWithStatusJSON(http.StatusUnauthorized, err.Error())
 			return

--- a/backend/timeline/internal/repositories/create_post_repository.go
+++ b/backend/timeline/internal/repositories/create_post_repository.go
@@ -29,7 +29,7 @@ func NewCreatePostRepository(conn *gorm.DB) *CreatePostRepository {
 	}
 }
 
-func (r *CreatePostRepository) Post(userID int, channelID int, content string) (*entities.Post, error) {
+func (r *CreatePostRepository) Post(channelID int, userID int, userName string, content string) (*entities.Post, error) {
 	var post post
 	post.ChannelId = channelID
 	post.UserId = userID
@@ -39,14 +39,14 @@ func (r *CreatePostRepository) Post(userID int, channelID int, content string) (
 	if result.Error != nil {
 		return nil, result.Error
 	}
-	return convertCreatePostRepositoryModelToEntity(&post), nil
+	return convertCreatePostRepositoryModelToEntity(&post, userName), nil
 }
 
-func convertCreatePostRepositoryModelToEntity(v *post) *entities.Post {
+func convertCreatePostRepositoryModelToEntity(v *post, userName string) *entities.Post {
 	return &entities.Post{
 		Id:        v.Id,
 		ChannelId: v.ChannelId,
-		User:      entities.User{Id: v.UserId},
+		User:      entities.User{Id: v.UserId, Name: userName},
 		Content:   v.Content,
 		CreatedAt: v.CreatedAt,
 		UpdatedAt: v.UpdatedAt,

--- a/backend/timeline/internal/usecases/create_post_usercase.go
+++ b/backend/timeline/internal/usecases/create_post_usercase.go
@@ -19,7 +19,7 @@ func NewCreatePostUsecase(cpr interfaces.CreatePostRepository, sr interfaces.Ser
 	}
 }
 
-func (u *CreatePostUsecase) Execute(userID int, serverID int, channelID int, content string) (*entities.Post, error) {
+func (u *CreatePostUsecase) Execute(serverID int, channelID int, userID int, userName string, content string) (*entities.Post, error) {
 	// 存在しているサーバーか確認する
 	if _, err := u.serverRepository.Get(serverID); err != nil {
 		return nil, err
@@ -29,5 +29,5 @@ func (u *CreatePostUsecase) Execute(userID int, serverID int, channelID int, con
 		return nil, err
 	}
 
-	return u.createPostRepository.Post(userID, channelID, content)
+	return u.createPostRepository.Post(channelID, userID, userName, content)
 }


### PR DESCRIPTION
closes #92 

## 概要
- user_id と user_name を jwt から取得するようにした
- レスポンスの形式を投稿取得 API と揃えるように controller.go で関数を追加した

## 動作確認
```
% curl -H POST 'localhost:9000/servers/1/channels/1/posts' -H 'Content-Type: application/json' -d '{"content" : "ワイワイ"}' -b "training-jwt=<<トークン>>"
```

```
{
    "id":17,
    "channel_id":1,
    "user_id":4,
    "user_name":"Takanori",
    "content":"ワイワイ",
    "created_at":"2024-06-28T15:00:28.859+09:00"
}
```