### PR TITLE
cookieをフロント側で取り回すための設定を追加

### DIFF
--- a/backend/user/src/main/kotlin/myapp/plugins/Routing.kt
+++ b/backend/user/src/main/kotlin/myapp/plugins/Routing.kt
@@ -67,6 +67,7 @@ fun Application.configureRouting() {
                             secure = true,
                             httpOnly = true,
                             extensions = mapOf("same-site" to "none"),
+                            path = "/",
                         )
                         call.respond(UserPublic(user.id, user.name))
                     }


### PR DESCRIPTION
# 概要
- cookieの有効範囲（path）が指定されてなかったので指定