### PR TITLE
Frontend/#95 サーバー一覧画面のAPI接続

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,1 +1,1 @@
-FRONTEND_HOST=http://localhost:3000
+FRONTEND_HOST=localhost:3000

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,2 +1,2 @@
 VITE_TIMELINE_API_BASE_URL=https://team-2_bk.member0005.track-bootcamp.run/
-VITE_USER_API_BASE_URL=https://team-2_bk.member0005.track-bootcamp.run/
+VITE_USER_API_BASE_URL=team-2_user.member0005.track-bootcamp.run/

--- a/frontend/src/components/page/servers/servers.tsx
+++ b/frontend/src/components/page/servers/servers.tsx
@@ -1,9 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
 import { ServerList } from "~/components/model/server";
 import { Card, Text } from "~/components/ui";
-import { mock } from "./mock";
+import { getServers } from "~/domains/servers";
 import styles from "./servers.module.scss";
 
 export const ServersPage = () => {
+	const { data: servers } = useQuery({
+		queryKey: ["servers"],
+		queryFn: getServers,
+	});
+
 	return (
 		<div className={styles.root}>
 			<div className={styles.card}>
@@ -13,7 +19,7 @@ export const ServersPage = () => {
 							🪐 Servers
 						</Text>
 					}
-					body={<ServerList servers={mock.servers} />}
+					body={<ServerList servers={servers ?? []} />}
 				/>
 			</div>
 		</div>

--- a/frontend/src/domains/channels/get-channels.ts
+++ b/frontend/src/domains/channels/get-channels.ts
@@ -6,7 +6,7 @@ type GetChannelsResponse = {
 };
 
 export const getChannels = async () => {
-	const { channels } = (await apiClient
+	const { channels } = (await apiClient("timeline")
 		.get("channels")
 		.json()) as GetChannelsResponse;
 	return channels;

--- a/frontend/src/domains/servers/get-servers.ts
+++ b/frontend/src/domains/servers/get-servers.ts
@@ -1,0 +1,13 @@
+import { apiClient } from "~/utils/api-client";
+import type { Server } from "./server";
+
+type GetServersResponse = {
+	servers: Server[];
+};
+
+export const getServers = async () => {
+	const { servers } = (await apiClient("timeline")
+		.get("servers")
+		.json()) as GetServersResponse;
+	return servers;
+};

--- a/frontend/src/domains/servers/index.ts
+++ b/frontend/src/domains/servers/index.ts
@@ -1,1 +1,2 @@
 export type { Server } from "./server";
+export { getServers } from "./get-servers";


### PR DESCRIPTION
# 概要
- サーバー一覧をAPIから取得できるようにした

# 動作確認
- [x] userサービスを再起動する
  - [x] `docker compose restart backend-user`
- [x] http://localhost:3000/login にアクセスしてログイン
- [x] 遷移先でサーバーに保存されているserverが標示されることを確認する