### PR TITLE
Frontend/#108 ログイン〜投稿一覧までの流れを作る

### DIFF
--- a/frontend/src/components/model/server/server-list.module.scss
+++ b/frontend/src/components/model/server/server-list.module.scss
@@ -1,5 +1,6 @@
 .root {
   list-style: none;
+  margin: 0;
   display: flex;
   flex-direction: column;
   padding: 0;

--- a/frontend/src/components/model/server/server-list.tsx
+++ b/frontend/src/components/model/server/server-list.tsx
@@ -12,7 +12,9 @@ type Props = {
 export const ServerList = ({ servers, onClickPlus }: Props) => {
 	// NOTE: ここにこの関数作るのちょっと違和感あるけど一旦このままで
 	// サーバーへのリンクを生成する
-	const urlToServer = (server: Server) => joinPaths(["/server", server.id]);
+	const urlToServer = (server: Server) =>
+		// NOTE: ホントは最後に開いてたチャンネルに飛ぶべきだけどちょっとめんどくさいので0にしてる
+		joinPaths(["/servers", server.id, "channels", "0"]);
 
 	const handleClickPlus = () => {
 		onClickPlus?.();


### PR DESCRIPTION
# 概要
- ログイン〜投稿一覧までを画面ぽちぽちでいけるように

# 動作確認
- [x] http://localhost:3000/login にアクセス
- [x] ログイン後にサーバー一覧画面に遷移することを確認
- [x] サーバーをクリックすると、投稿一覧画面に遷移することを確認

close #108 